### PR TITLE
Document use of feature flags including enable-catalog-schemas

### DIFF
--- a/docs/brokerpak-dissection.md
+++ b/docs/brokerpak-dissection.md
@@ -534,7 +534,7 @@ Configuration parameters that my be set as part of a plan or set by the user thr
 | type | field type |
 | details | human readable description of field |
 | default | (optional) default value for field |
-| constraints | (optional) Holds additional JSONSchema validation for the field. The following keys are supported: `examples`, `const`, `multipleOf`, `minimum`, `maximum`, `exclusiveMaximum`, `exclusiveMinimum`, `maxLength`, `minLength`, `pattern`, `maxItems`, `minItems`, `maxProperties`, `minProperties`, and `propertyNames`.|
+| constraints | (optional) Holds additional JSONSchema validation for the field. Feature flag `enable-catalog-schemas` controls whether to serve Json schemas in catalog. The following keys are supported: `examples`, `const`, `multipleOf`, `minimum`, `maximum`, `exclusiveMaximum`, `exclusiveMinimum`, `maxLength`, `minLength`, `pattern`, `maxItems`, `minItems`, `maxProperties`, `minProperties`, and `propertyNames`.|
 
 > input fields must be declared as terraform *variables*. Failure to do so will result in failures to build brokerpak.
 

--- a/docs/brokerpak-specification.md
+++ b/docs/brokerpak-specification.md
@@ -307,7 +307,7 @@ Outputs are _only_ validated on integration tests.
 | details* | string | Provides explanation about the purpose of the variable. |
 | default | any | The default value for this field. If `null`, the field MUST be marked as required. If a string, it will be executed as a HIL expression and cast to the appropriate type described in the `type` field. See the [Expression language reference](#expression-language-reference) section for more information about what's available. |
 | enum | map of any:string | Valid values for the field and their human-readable descriptions suitable for displaying in a drop-down list. |
-| constraints | map of string:any | Holds additional JSONSchema validation for the field. The following keys are supported: `examples`, `const`, `multipleOf`, `minimum`, `maximum`, `exclusiveMaximum`, `exclusiveMinimum`, `maxLength`, `minLength`, `pattern`, `maxItems`, `minItems`, `maxProperties`, `minProperties`, and `propertyNames`. |
+| constraints | map of string:any | Holds additional JSONSchema validation for the field. Feature flag `enable-catalog-schemas` controls whether to serve Json schemas in catalog. The following keys are supported: `examples`, `const`, `multipleOf`, `minimum`, `maximum`, `exclusiveMaximum`, `exclusiveMinimum`, `maxLength`, `minLength`, `pattern`, `maxItems`, `minItems`, `maxProperties`, `minProperties`, and `propertyNames`. |
 
 #### Computed Variable Object
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,6 +42,22 @@ Broker service configuration values:
 | <tt>SECURITY_USER_PASSWORD</tt> <b>*</b> | api.password | string | <p>Broker authentication password</p>|
 | <tt>PORT</tt> | api.port | string | <p>Port to bind broker to</p>|
 
+## Feature flags Configuration
+
+Feature flags can be toggled through the following configuration values. See also [Feature Flags section in tile.yml ](https://github.com/cloudfoundry-incubator/cloud-service-broker/blob/master/tile.yml#L133-L199) or [source code occurences of "toggles.Features.Toggle"](https://github.com/cloudfoundry-incubator/cloud-service-broker/search?q=toggles.Features.Toggle&type=code)
+| Environment Variable | Config File Value | Type | Description | Default |
+|----------------------|------|-------------|------------------|----------|
+| <tt>GSB_COMPATIBILITY_ENABLE_BUILTIN_BROKERPAKS</tt> <b>*</b> | compatibility.enable_builtin_brokerpaks | Boolean | <p>Load brokerpaks that are built-in to the software.</p>| "true" |
+| <tt>GSB_COMPATIBILITY_ENABLE_BUILTIN_SERVICES</tt> <b>*</b> | compatibility.enable_builtin_services | Boolean | <p>Enable services that are built in to the broker i.e. not brokerpaks.</p>| "true" |
+| <tt>GSB_COMPATIBILITY_ENABLE_CATALOG_SCHEMAS</tt> <b>*</b> | compatibility.enable_catalog_schemas | Boolean | <p>Enable generating JSONSchema for the service catalog.</p>| "false" |
+| <tt>GSB_COMPATIBILITY_ENABLE_CF_SHARING</tt> <b>*</b> | compatibility.enable_cf_sharing | Boolean | <p>Set all services to have the Sharable flag so they can be shared</p>| "false" |
+| <tt>GSB_COMPATIBILITY_ENABLE_EOL_SERVICES</tt> <b>*</b> | compatibility.enable_eol_services | Boolean | <p>Enable broker services that are end of life.</p>| "false" |
+| <tt>GSB_COMPATIBILITY_ENABLE_GCP_BETA_SERVICES</tt> <b>*</b> | compatibility.enable_gcp_beta_services | Boolean | <p>Enable services that are in GCP Beta. These have no SLA or support</p>| "true" |
+| <tt>GSB_COMPATIBILITY_ENABLE_GCP_DEPRECATED_SERVICES</tt> <b>*</b> | compatibility.enable_gcp_deprecated_services | Boolean | <p>Enable services that use deprecated GCP components.</p>| "false" |
+| <tt>GSB_COMPATIBILITY_ENABLE_PREVIEW_SERVICES</tt> <b>*</b> | compatibility.enable_preview_services | Boolean | <p>Enable services that are new to the broker this release.</p>| "true" |
+| <tt>GSB_COMPATIBILITY_ENABLE_TERRAFORM_SERVICES</tt> <b>*</b> | compatibility.enable_terraform_services | Boolean | <p>Enable services that use the experimental, unstable, Terraform back-end.</p>| "false" |
+| <tt>GSB_COMPATIBILITY_ENABLE_UNMAINTAINED_SERVICES</tt> <b>*</b> | compatibility.enable_unmaintained_services | Boolean | <p>Enable broker services that are unmaintained.</p>| "false" |
+
 ## Credhub Configuration
 The broker supports passing credentials to apps via [credhub references](https://github.com/cloudfoundry-incubator/credhub/blob/master/docs/secure-service-credentials.md#service-brokers), thus keeping them private to the application (they won't show up in `cf env app_name` output.)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -79,7 +79,7 @@ Add these to the `env` section of `manifest.yml`
 
 #### [Optional environment variables](#optional-env)
 
-See [the customization documentation](https://github.com/pivotal/cloud-service-broker/blob/master/docs/customization.md)
+See [the configuration documentation](https://github.com/pivotal/cloud-service-broker/blob/master/docs/configuration.md)
 for instructions about providing database name and port overrides, SSL certificates, custom service plans, and more.
 
 #### [Push the service broker to CF and enable services](#push)


### PR DESCRIPTION
This PR makes explicit how to use feature flags, in particular to turn on serving Json Schema into catalog (relates to #166)

I also noticed that `csb generate customize` generates HTML documentation including feature flags, but this file is not visible on github. I'm not sure whether/how to mention presence of this `csb generate customize` and whether some other documentation element describe it.