### PR TITLE
Enlarge DB column to allow for larger Terraform state

### DIFF
--- a/db_service/migrations.go
+++ b/db_service/migrations.go
@@ -22,7 +22,7 @@ import (
 	"github.com/jinzhu/gorm"
 )
 
-const numMigrations = 7
+const numMigrations = 8
 
 // runs schema migrations on the provided service broker database to get it up to date
 func RunMigrations(db *gorm.DB) error {
@@ -78,6 +78,10 @@ func RunMigrations(db *gorm.DB) error {
 		} else {
 			return db.Model(&models.ProvisionRequestDetailsV2{}).ModifyColumn("request_details", "text").Error
 		}
+	}
+
+	migrations[7] = func() error { // v4.2.0
+		return autoMigrateTables(db, &models.TerraformDeploymentV2{})
 	}
 
 	var lastMigrationNumber = -1

--- a/db_service/models/db.go
+++ b/db_service/models/db.go
@@ -72,4 +72,4 @@ type CloudOperation CloudOperationV1
 
 // TerraformDeployment holds Terraform state and plan information for resources
 // that use that execution system.
-type TerraformDeployment TerraformDeploymentV1
+type TerraformDeployment TerraformDeploymentV2

--- a/db_service/models/historical_db.go
+++ b/db_service/models/historical_db.go
@@ -225,6 +225,29 @@ type TerraformDeploymentV1 struct {
 	LastOperationMessage string `sql:"type:text"`
 }
 
+// Expands the size of the Workspace column to handle deployments where the
+// Terraform workspace is greater than 64K. (mediumtext allows for workspaces up
+// to 16384K.)
+type TerraformDeploymentV2 struct {
+	ID        string `gorm:"primary_key",sql:"type:varchar(1024)"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt *time.Time
+
+	// Workspace contains a JSON serialized version of the Terraform workspace.
+	Workspace string `sql:"type:mediumtext"`
+
+	// LastOperationType describes the last operation being performed on the resource.
+	LastOperationType string
+
+	// LastOperationState holds one of the following strings "in progress", "succeeded", "failed".
+	// These mirror the OSB API.
+	LastOperationState string
+
+	// LastOperationMessage is a description that can be passed back to the user.
+	LastOperationMessage string `sql:"type:text"`
+}
+
 // TableName returns a consistent table name (`tf_deployment`) for gorm so
 // multiple structs from different versions of the database all operate on the
 // same table.


### PR DESCRIPTION
Expands the size of the Workspace column to handle deployments where the Terraform workspace is greater than 64K. 

We need this for our eks-brokerpak since the `.tfstate` ends up about 196K...!

Mediumtext allows for workspaces up to 16384K.

