### PR TITLE
Fix problem with TerraformDeploymentV2 migration

### DIFF
--- a/db_service/models/historical_db.go
+++ b/db_service/models/historical_db.go
@@ -225,6 +225,13 @@ type TerraformDeploymentV1 struct {
 	LastOperationMessage string `sql:"type:text"`
 }
 
+// TableName returns a consistent table name (`tf_deployment`) for gorm so
+// multiple structs from different versions of the database all operate on the
+// same table.
+func (TerraformDeploymentV1) TableName() string {
+	return "terraform_deployments"
+}
+
 // Expands the size of the Workspace column to handle deployments where the
 // Terraform workspace is greater than 64K. (mediumtext allows for workspaces up
 // to 16384K.)
@@ -248,9 +255,9 @@ type TerraformDeploymentV2 struct {
 	LastOperationMessage string `sql:"type:text"`
 }
 
-// TableName returns a consistent table name (`tf_deployment`) for gorm so
-// multiple structs from different versions of the database all operate on the
-// same table.
-func (TerraformDeploymentV1) TableName() string {
+// TableName returns a consistent table name (`provision_request_details`) for
+// gorm so multiple structs from different versions of the database all operate
+// on the same table.
+func (TerraformDeploymentV2) TableName() string {
 	return "terraform_deployments"
 }


### PR DESCRIPTION
This PR fixes a problem with my previous fix for a problem where old DBs aren't handling larger Terraform workspace state. [Here's the description of the problem with my previous fix for the problem](https://github.com/cloudfoundry-incubator/cloud-service-broker/pull/168#issuecomment-768519993). 😳 🤦 😞 

Once merged this should probably be tagged v0.2.3 ASAP to minimize the set of people who will end up with a stray/unused DB table as a result of deploying my previous PR in 0.2.2. (It's relatively harmless, but even so, sorry about that.)

Tagging @erniebilling as he's likely best equipped to evaluate and merge.