### PR TITLE
Expose context and x_broker_api_originating_identity to brokerpaks

### DIFF
--- a/brokerapi/brokers/brokers_test.go
+++ b/brokerapi/brokers/brokers_test.go
@@ -374,7 +374,7 @@ func TestGCPServiceBroker_Deprovision(t *testing.T) {
 				failIfErr(t, "deprovisioning", err)
 
 				assertEqual(t, "deprovision calls should match", 1, stub.Provider.DeprovisionCallCount())
-				_, _, _,actualVarContext := stub.Provider.DeprovisionArgsForCall(0)
+				_, _, _, actualVarContext := stub.Provider.DeprovisionArgsForCall(0)
 				expectedOriginatingIdentityMap := `{"platform":"cloudfoundry","value":{"user_id":"683ea748-3092-4ff4-b656-39cacc4d5360"}}`
 
 				assertEqual(t, "originatingIdentity should match", expectedOriginatingIdentityMap, actualVarContext.GetString("originatingIdentity"))

--- a/brokerapi/brokers/brokers_test.go
+++ b/brokerapi/brokers/brokers_test.go
@@ -702,6 +702,19 @@ func TestGCPServiceBroker_Update(t *testing.T) {
 				failIfErr(t, "update", err)
 			},
 		},
+		"originating-header": {
+			ServiceState: StateProvisioned,
+			Check: func(t *testing.T, broker *ServiceBroker, stub *serviceStub) {
+				header := "cloudfoundry eyANCiAgInVzZXJfaWQiOiAiNjgzZWE3NDgtMzA5Mi00ZmY0LWI2NTYtMzljYWNjNGQ1MzYwIg0KfQ=="
+				newContext := context.WithValue(context.Background(), "originatingIdentity", header)
+				broker.Update(newContext, fakeInstanceId, stub.UpdateDetails(), true)
+				assertEqual(t, "update calls should match", 1, stub.Provider.UpdateCallCount())
+				_, actualVarContext := stub.Provider.UpdateArgsForCall(0)
+				expectedOriginatingIdentityMap := `{"platform":"cloudfoundry","value":{"user_id":"683ea748-3092-4ff4-b656-39cacc4d5360"}}`
+
+				assertEqual(t, "originatingIdentity should match", expectedOriginatingIdentityMap, actualVarContext.GetString("originatingIdentity"))
+			},
+		},
 		"missing-instance": {
 			ServiceState: StateProvisioned,
 			AsyncService: true,

--- a/brokerapi/brokers/service_broker.go
+++ b/brokerapi/brokers/service_broker.go
@@ -287,7 +287,7 @@ func (broker *ServiceBroker) Bind(ctx context.Context, instanceID, bindingID str
 
 	// validate parameters meet the service's schema and merge the plan's vars with
 	// the user's
-	vars, err := serviceDefinition.BindVariables(*instanceRecord, bindingID, details, plan)
+	vars, err := serviceDefinition.BindVariables(*instanceRecord, bindingID, details, plan, request.DecodeOriginatingIdentityHeader(ctx))
 	if err != nil {
 		return brokerapi.Binding{}, err
 	}
@@ -436,7 +436,7 @@ func (broker *ServiceBroker) Unbind(ctx context.Context, instanceID, bindingID s
 		RawParameters: json.RawMessage(pr.RequestDetails),
 	}
 
-	vars, err := serviceDefinition.BindVariables(*instance, bindingID, bindDetails, plan)
+	vars, err := serviceDefinition.BindVariables(*instance, bindingID, bindDetails, plan, request.DecodeOriginatingIdentityHeader(ctx))
 	if err != nil {
 		return brokerapi.UnbindSpec{}, err
 	}

--- a/brokerapi/brokers/service_broker.go
+++ b/brokerapi/brokers/service_broker.go
@@ -605,7 +605,7 @@ func (broker *ServiceBroker) Update(ctx context.Context, instanceID string, deta
 
 	// validate parameters meet the service's schema and merge the user vars with
 	// the plan's
-	vars, err := brokerService.UpdateVariables(instanceID, details, json.RawMessage(pr.RequestDetails), *plan)
+	vars, err := brokerService.UpdateVariables(instanceID, details, json.RawMessage(pr.RequestDetails), *plan, request.DecodeOriginatingIdentityHeader(ctx))
 	if err != nil {
 		return response, err
 	}

--- a/brokerapi/brokers/service_broker.go
+++ b/brokerapi/brokers/service_broker.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/cloudfoundry-incubator/cloud-service-broker/utils/request"
 	"net/http"
 
 	"code.cloudfoundry.org/lager"
@@ -33,7 +34,7 @@ import (
 )
 
 var (
-	invalidUserInputMsg        = "User supplied paramaters must be in the form of a valid JSON map."
+	invalidUserInputMsg        = "User supplied parameters must be in the form of a valid JSON map."
 	ErrInvalidUserInput        = brokerapi.NewFailureResponse(errors.New(invalidUserInputMsg), http.StatusBadRequest, "parsing-user-request")
 	ErrGetInstancesUnsupported = brokerapi.NewFailureResponse(errors.New("the service_instances endpoint is unsupported"), http.StatusBadRequest, "unsupported")
 	ErrGetBindingsUnsupported  = brokerapi.NewFailureResponse(errors.New("the service_bindings endpoint is unsupported"), http.StatusBadRequest, "unsupported")
@@ -133,7 +134,7 @@ func (broker *ServiceBroker) Provision(ctx context.Context, instanceID string, d
 
 	// validate parameters meet the service's schema and merge the user vars with
 	// the plan's
-	vars, err := brokerService.ProvisionVariables(instanceID, details, *plan)
+	vars, err := brokerService.ProvisionVariables(instanceID, details, *plan, request.DecodeOriginatingIdentityHeader(ctx))
 	if err != nil {
 		return brokerapi.ProvisionedServiceSpec{}, err
 	}
@@ -213,7 +214,7 @@ func (broker *ServiceBroker) Deprovision(ctx context.Context, instanceID string,
 
 	// validate parameters meet the service's schema and merge the user vars with
 	// the plan's
-	vars, err := brokerService.ProvisionVariables(instanceID, provisionDetails, *plan)
+	vars, err := brokerService.ProvisionVariables(instanceID, provisionDetails, *plan, request.DecodeOriginatingIdentityHeader(ctx))
 	if err != nil {
 		return response, err
 	}
@@ -643,3 +644,5 @@ func (broker *ServiceBroker) Update(ctx context.Context, instanceID string, deta
 func isValidOrEmptyJSON(msg json.RawMessage) bool {
 	return msg == nil || len(msg) == 0 || json.Valid(msg)
 }
+
+

--- a/brokerapi/brokers/service_broker.go
+++ b/brokerapi/brokers/service_broker.go
@@ -644,5 +644,3 @@ func (broker *ServiceBroker) Update(ctx context.Context, instanceID string, deta
 func isValidOrEmptyJSON(msg json.RawMessage) bool {
 	return msg == nil || len(msg) == 0 || json.Valid(msg)
 }
-
-

--- a/docs/brokerpak-specification.md
+++ b/docs/brokerpak-specification.md
@@ -462,7 +462,7 @@ Note that the order the variables are combined in code is slightly different.
 Moving default variables to be loaded third allow their computed values to make more sense.
 This is because they can resolve variables to the user's values first.
 
-#### Provision
+#### Provision/Deprovision
 
 * `request.service_id` - _string_ The GUID of the requested service.
 * `request.plan_id` - _string_ The ID of the requested plan. Plan IDs are unique within an instance.
@@ -471,8 +471,10 @@ This is because they can resolve variables to the user's values first.
    * `request.default_labels.pcf-organization-guid` - _string_ Mapped from [cloudfoundry context](https://github.com/openservicebrokerapi/servicebroker/blob/master/profile.md#cloud-foundry-context-object) `organization_guid`
    * `request.default_labels.pcf-space-guid` - _string_ Mapped from [cloudfoundry context](https://github.com/openservicebrokerapi/servicebroker/blob/master/profile.md#cloud-foundry-context-object) `space_guid`
    * `request.default_labels.pcf-instance-id` - _string_ Mapped from the ID of the requested instance. 
+* `request.context` - _map[string]any_ Mapped from [cloudfoundry context](https://github.com/openservicebrokerapi/servicebroker/blob/master/profile.md#cloud-foundry-context-object).
+* `request.x_broker_api_originating_identity` - _map[string]any_ Mapped from [cloudfoundry `x_broker_api_originating_identity` header](https://github.com/openservicebrokerapi/servicebroker/blob/master/profile.md#originating-identity-header)
    
-#### Bind
+#### Bind/Unbind
 
 * `request.binding_id` - _string_ The ID of the new binding.
 * `request.instance_id` - _string_ The ID of the existing instance to bind to.

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -577,10 +577,24 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 				Default:   "default",
 				Overwrite: false,
 			},
+			{
+				Name:      "osb_context",
+				Default:   `${json.marshal(request.context)}`,
+				Overwrite: true,
+				Type:      "object",
+			},
+			{
+				Name:      "originatingIdentity",
+				Default:   `${json.marshal(request.x_broker_api_originating_identity)}`,
+				Overwrite: true,
+				Type:      "object",
+			},
 		},
 	}
 
 	cases := map[string]struct {
+		RawContext string
+		OriginatingIdentity map[string]interface{}
 		// precedence order - lowest number should win
 		UserParams         string                 // 4
 		ProvisionOverrides map[string]interface{} // 3
@@ -598,6 +612,31 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 				"location":      "us",
 				"name":          "name-us",
 				"maybe-missing": "default",
+				"osb_context": map[string]interface{}{},
+				"originatingIdentity": map[string]interface{}{},
+			},
+		},
+		"includes request context information": {
+			UserParams:        "",
+			RawContext:  `{"platform": "cloudfoundry", "organization_name": "acceptance"}`,
+			OriginatingIdentity:  map[string]interface{}{
+				"platform": "cloudfoundry",
+				"value": map[string]string{
+					"user_id": "683ea748-3092-4ff4-b656-39cacc4d5360",
+				}},
+			ServiceProperties: map[string]interface{}{},
+			ExpectedContext: map[string]interface{}{
+				"location":      "us",
+				"name":          "name-us",
+				"maybe-missing": "default",
+				"osb_context": map[string]interface{}{
+					"platform": "cloudfoundry",
+					"organization_name": "acceptance",
+				},
+				"originatingIdentity": map[string]interface{}{
+					"platform": "cloudfoundry",
+					"value": map[string]interface{}{"user_id": "683ea748-3092-4ff4-b656-39cacc4d5360"},
+				},
 			},
 		},
 		"service has missing param": {
@@ -607,6 +646,8 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 				"location":      "us",
 				"name":          "name-us",
 				"maybe-missing": "custom",
+				"osb_context": map[string]interface{}{},
+				"originatingIdentity": map[string]interface{}{},
 			},
 		},
 		"location gets truncated": {
@@ -616,6 +657,8 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 				"location":      "averylongl",
 				"name":          "name-averylonglocation",
 				"maybe-missing": "default",
+				"osb_context": map[string]interface{}{},
+				"originatingIdentity": map[string]interface{}{},
 			},
 		},
 		"user location and name": {
@@ -625,6 +668,8 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 				"location":      "eu",
 				"name":          "foo",
 				"maybe-missing": "default",
+				"osb_context": map[string]interface{}{},
+				"originatingIdentity": map[string]interface{}{},
 			},
 		},
 		"user tries to overwrite service var": {
@@ -635,6 +680,8 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 				"name":             "foo",
 				"maybe-missing":    "default",
 				"service-provided": "custom",
+				"osb_context": map[string]interface{}{},
+				"originatingIdentity": map[string]interface{}{},
 			},
 		},
 		"operator defaults override computed defaults": {
@@ -646,6 +693,8 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 				"location":      "eu",
 				"name":          "name-eu",
 				"maybe-missing": "default",
+				"osb_context": map[string]interface{}{},
+				"originatingIdentity": map[string]interface{}{},
 			},
 		},
 		"user values override operator defaults": {
@@ -657,6 +706,8 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 				"location":      "nz",
 				"name":          "name-nz",
 				"maybe-missing": "default",
+				"osb_context": map[string]interface{}{},
+				"originatingIdentity": map[string]interface{}{},
 			},
 		},
 		"operator defaults are not evaluated": {
@@ -668,6 +719,8 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 				"location":      "us",
 				"name":          "foo-${location}",
 				"maybe-missing": "default",
+				"osb_context": map[string]interface{}{},
+				"originatingIdentity": map[string]interface{}{},
 			},
 		},
 		"invalid-request": {
@@ -684,6 +737,8 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 				"location":      "eu",
 				"name":          "name-eu",
 				"maybe-missing": "default",
+				"osb_context": map[string]interface{}{},
+				"originatingIdentity": map[string]interface{}{},
 			},
 		},
 		"global_default override defaults but not computed defaults": {
@@ -696,6 +751,8 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 				"location":      "az",
 				"name":          "name-az",
 				"maybe-missing": "default",
+				"osb_context": map[string]interface{}{},
+				"originatingIdentity": map[string]interface{}{},
 			},
 		},
 		"bogus global default json": {
@@ -708,6 +765,8 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 				"location":      "az",
 				"name":          "name-az",
 				"maybe-missing": "default",
+				"osb_context": map[string]interface{}{},
+				"originatingIdentity": map[string]interface{}{},
 			},
 			ExpectedError: fmt.Errorf("Failed unmarshaling config value provision.defaults"),
 		},
@@ -718,6 +777,8 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 				"location":      "eu",
 				"name":          "foo",
 				"maybe-missing": "default",
+				"osb_context": map[string]interface{}{},
+				"originatingIdentity": map[string]interface{}{},
 			},
 		},
 		"update location and name": {
@@ -728,6 +789,8 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 				"location":      "eu",
 				"name":          "update",
 				"maybe-missing": "default",
+				"osb_context": map[string]interface{}{},
+				"originatingIdentity": map[string]interface{}{},
 			},
 		},
 	}
@@ -742,10 +805,10 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 			}
 			defer viper.Reset()
 
-			details := brokerapi.UpdateDetails{RawParameters: json.RawMessage(tc.UserParams)}
+			details := brokerapi.UpdateDetails{RawParameters: json.RawMessage(tc.UserParams), RawContext: json.RawMessage(tc.RawContext)}
 			provisionDetails := json.RawMessage(tc.ProvisionDetails)
 			plan := ServicePlan{ServiceProperties: tc.ServiceProperties, ProvisionOverrides: tc.ProvisionOverrides}
-			vars, err := service.UpdateVariables("instance-id-here", details, provisionDetails, plan)
+			vars, err := service.UpdateVariables("instance-id-here", details, provisionDetails, plan, tc.OriginatingIdentity)
 
 			expectError(t, tc.ExpectedError, err)
 

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -343,7 +343,7 @@ func TestServiceDefinition_ProvisionVariables(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		RawContext string
+		RawContext          string
 		OriginatingIdentity map[string]interface{}
 		// precedence order - lowest number should win
 		UserParams         string                 // 4
@@ -358,17 +358,17 @@ func TestServiceDefinition_ProvisionVariables(t *testing.T) {
 			UserParams:        "",
 			ServiceProperties: map[string]interface{}{},
 			ExpectedContext: map[string]interface{}{
-				"location":      "us",
-				"name":          "name-us",
-				"maybe-missing": "default",
-				"osb_context": map[string]interface{}{},
+				"location":            "us",
+				"name":                "name-us",
+				"maybe-missing":       "default",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},
 		"includes request context information": {
-			UserParams:        "",
-			RawContext:  `{"platform": "cloudfoundry", "organization_name": "acceptance"}`,
-			OriginatingIdentity:  map[string]interface{}{
+			UserParams: "",
+			RawContext: `{"platform": "cloudfoundry", "organization_name": "acceptance"}`,
+			OriginatingIdentity: map[string]interface{}{
 				"platform": "cloudfoundry",
 				"value": map[string]string{
 					"user_id": "683ea748-3092-4ff4-b656-39cacc4d5360",
@@ -379,12 +379,12 @@ func TestServiceDefinition_ProvisionVariables(t *testing.T) {
 				"name":          "name-us",
 				"maybe-missing": "default",
 				"osb_context": map[string]interface{}{
-					"platform": "cloudfoundry",
+					"platform":          "cloudfoundry",
 					"organization_name": "acceptance",
-				 },
+				},
 				"originatingIdentity": map[string]interface{}{
 					"platform": "cloudfoundry",
-					"value": map[string]interface{}{"user_id": "683ea748-3092-4ff4-b656-39cacc4d5360"},
+					"value":    map[string]interface{}{"user_id": "683ea748-3092-4ff4-b656-39cacc4d5360"},
 				},
 			},
 		},
@@ -392,10 +392,10 @@ func TestServiceDefinition_ProvisionVariables(t *testing.T) {
 			ServiceProperties: map[string]interface{}{"maybe-missing": "custom"}, // 2
 			UserParams:        "",                                                // 4
 			ExpectedContext: map[string]interface{}{
-				"location":      "us",
-				"name":          "name-us",
-				"maybe-missing": "custom",
-				"osb_context": map[string]interface{}{},
+				"location":            "us",
+				"name":                "name-us",
+				"maybe-missing":       "custom",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},
@@ -403,10 +403,10 @@ func TestServiceDefinition_ProvisionVariables(t *testing.T) {
 			ServiceProperties: map[string]interface{}{},            // 2
 			UserParams:        `{"location": "averylonglocation"}`, // 4
 			ExpectedContext: map[string]interface{}{
-				"location":      "averylongl",
-				"name":          "name-averylonglocation",
-				"maybe-missing": "default",
-				"osb_context": map[string]interface{}{},
+				"location":            "averylongl",
+				"name":                "name-averylonglocation",
+				"maybe-missing":       "default",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},
@@ -414,10 +414,10 @@ func TestServiceDefinition_ProvisionVariables(t *testing.T) {
 			ServiceProperties: map[string]interface{}{},           // 2
 			UserParams:        `{"location": "eu", "name":"foo"}`, // 4
 			ExpectedContext: map[string]interface{}{
-				"location":      "eu",
-				"name":          "foo",
-				"maybe-missing": "default",
-				"osb_context": map[string]interface{}{},
+				"location":            "eu",
+				"name":                "foo",
+				"maybe-missing":       "default",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},
@@ -425,11 +425,11 @@ func TestServiceDefinition_ProvisionVariables(t *testing.T) {
 			ServiceProperties: map[string]interface{}{"service-provided": "custom"},          // 2
 			UserParams:        `{"location": "eu", "name":"foo", "service-provided":"test"}`, // 4
 			ExpectedContext: map[string]interface{}{
-				"location":         "eu",
-				"name":             "foo",
-				"maybe-missing":    "default",
-				"service-provided": "custom",
-				"osb_context": map[string]interface{}{},
+				"location":            "eu",
+				"name":                "foo",
+				"maybe-missing":       "default",
+				"service-provided":    "custom",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},
@@ -439,10 +439,10 @@ func TestServiceDefinition_ProvisionVariables(t *testing.T) {
 			DefaultOverride:   `{"location":"eu"}`,      // 5
 			GlobalDefaults:    `{"location":"az"}`,      // 6
 			ExpectedContext: map[string]interface{}{
-				"location":      "eu",
-				"name":          "name-eu",
-				"maybe-missing": "default",
-				"osb_context": map[string]interface{}{},
+				"location":            "eu",
+				"name":                "name-eu",
+				"maybe-missing":       "default",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},
@@ -452,10 +452,10 @@ func TestServiceDefinition_ProvisionVariables(t *testing.T) {
 			DefaultOverride:   `{"location":"eu"}`,      // 5
 			GlobalDefaults:    "{}",
 			ExpectedContext: map[string]interface{}{
-				"location":      "nz",
-				"name":          "name-nz",
-				"maybe-missing": "default",
-				"osb_context": map[string]interface{}{},
+				"location":            "nz",
+				"name":                "name-nz",
+				"maybe-missing":       "default",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},
@@ -465,10 +465,10 @@ func TestServiceDefinition_ProvisionVariables(t *testing.T) {
 			DefaultOverride:   `{"name":"foo-${location}"}`, // 5
 			GlobalDefaults:    "{}",
 			ExpectedContext: map[string]interface{}{
-				"location":      "us",
-				"name":          "foo-${location}",
-				"maybe-missing": "default",
-				"osb_context": map[string]interface{}{},
+				"location":            "us",
+				"name":                "foo-${location}",
+				"maybe-missing":       "default",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},
@@ -483,10 +483,10 @@ func TestServiceDefinition_ProvisionVariables(t *testing.T) {
 			DefaultOverride:    "{}",                                     // 5
 			GlobalDefaults:     `{"location":"az"}`,                      // 6
 			ExpectedContext: map[string]interface{}{
-				"location":      "eu",
-				"name":          "name-eu",
-				"maybe-missing": "default",
-				"osb_context": map[string]interface{}{},
+				"location":            "eu",
+				"name":                "name-eu",
+				"maybe-missing":       "default",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},
@@ -497,10 +497,10 @@ func TestServiceDefinition_ProvisionVariables(t *testing.T) {
 			DefaultOverride:    "{}",                     // 5
 			GlobalDefaults:     `{"location":"az"}`,      // 6
 			ExpectedContext: map[string]interface{}{
-				"location":      "az",
-				"name":          "name-az",
-				"maybe-missing": "default",
-				"osb_context": map[string]interface{}{},
+				"location":            "az",
+				"name":                "name-az",
+				"maybe-missing":       "default",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},
@@ -511,10 +511,10 @@ func TestServiceDefinition_ProvisionVariables(t *testing.T) {
 			DefaultOverride:    "{}",                     // 5
 			GlobalDefaults:     `{"location","az"}`,      // 6
 			ExpectedContext: map[string]interface{}{
-				"location":      "az",
-				"name":          "name-az",
-				"maybe-missing": "default",
-				"osb_context": map[string]interface{}{},
+				"location":            "az",
+				"name":                "name-az",
+				"maybe-missing":       "default",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 			ExpectedError: fmt.Errorf("Failed unmarshaling config value provision.defaults"),
@@ -593,7 +593,7 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		RawContext string
+		RawContext          string
 		OriginatingIdentity map[string]interface{}
 		// precedence order - lowest number should win
 		UserParams         string                 // 4
@@ -609,17 +609,17 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 			UserParams:        "",
 			ServiceProperties: map[string]interface{}{},
 			ExpectedContext: map[string]interface{}{
-				"location":      "us",
-				"name":          "name-us",
-				"maybe-missing": "default",
-				"osb_context": map[string]interface{}{},
+				"location":            "us",
+				"name":                "name-us",
+				"maybe-missing":       "default",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},
 		"includes request context information": {
-			UserParams:        "",
-			RawContext:  `{"platform": "cloudfoundry", "organization_name": "acceptance"}`,
-			OriginatingIdentity:  map[string]interface{}{
+			UserParams: "",
+			RawContext: `{"platform": "cloudfoundry", "organization_name": "acceptance"}`,
+			OriginatingIdentity: map[string]interface{}{
 				"platform": "cloudfoundry",
 				"value": map[string]string{
 					"user_id": "683ea748-3092-4ff4-b656-39cacc4d5360",
@@ -630,12 +630,12 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 				"name":          "name-us",
 				"maybe-missing": "default",
 				"osb_context": map[string]interface{}{
-					"platform": "cloudfoundry",
+					"platform":          "cloudfoundry",
 					"organization_name": "acceptance",
 				},
 				"originatingIdentity": map[string]interface{}{
 					"platform": "cloudfoundry",
-					"value": map[string]interface{}{"user_id": "683ea748-3092-4ff4-b656-39cacc4d5360"},
+					"value":    map[string]interface{}{"user_id": "683ea748-3092-4ff4-b656-39cacc4d5360"},
 				},
 			},
 		},
@@ -643,10 +643,10 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 			ServiceProperties: map[string]interface{}{"maybe-missing": "custom"}, // 2
 			UserParams:        "",                                                // 4
 			ExpectedContext: map[string]interface{}{
-				"location":      "us",
-				"name":          "name-us",
-				"maybe-missing": "custom",
-				"osb_context": map[string]interface{}{},
+				"location":            "us",
+				"name":                "name-us",
+				"maybe-missing":       "custom",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},
@@ -654,10 +654,10 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 			ServiceProperties: map[string]interface{}{},            // 2
 			UserParams:        `{"location": "averylonglocation"}`, // 4
 			ExpectedContext: map[string]interface{}{
-				"location":      "averylongl",
-				"name":          "name-averylonglocation",
-				"maybe-missing": "default",
-				"osb_context": map[string]interface{}{},
+				"location":            "averylongl",
+				"name":                "name-averylonglocation",
+				"maybe-missing":       "default",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},
@@ -665,10 +665,10 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 			ServiceProperties: map[string]interface{}{},           // 2
 			UserParams:        `{"location": "eu", "name":"foo"}`, // 4
 			ExpectedContext: map[string]interface{}{
-				"location":      "eu",
-				"name":          "foo",
-				"maybe-missing": "default",
-				"osb_context": map[string]interface{}{},
+				"location":            "eu",
+				"name":                "foo",
+				"maybe-missing":       "default",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},
@@ -676,11 +676,11 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 			ServiceProperties: map[string]interface{}{"service-provided": "custom"},          // 2
 			UserParams:        `{"location": "eu", "name":"foo", "service-provided":"test"}`, // 4
 			ExpectedContext: map[string]interface{}{
-				"location":         "eu",
-				"name":             "foo",
-				"maybe-missing":    "default",
-				"service-provided": "custom",
-				"osb_context": map[string]interface{}{},
+				"location":            "eu",
+				"name":                "foo",
+				"maybe-missing":       "default",
+				"service-provided":    "custom",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},
@@ -690,10 +690,10 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 			DefaultOverride:   `{"location":"eu"}`,      // 5
 			GlobalDefaults:    `{"location":"az"}`,      // 6
 			ExpectedContext: map[string]interface{}{
-				"location":      "eu",
-				"name":          "name-eu",
-				"maybe-missing": "default",
-				"osb_context": map[string]interface{}{},
+				"location":            "eu",
+				"name":                "name-eu",
+				"maybe-missing":       "default",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},
@@ -703,10 +703,10 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 			DefaultOverride:   `{"location":"eu"}`,      // 5
 			GlobalDefaults:    "{}",
 			ExpectedContext: map[string]interface{}{
-				"location":      "nz",
-				"name":          "name-nz",
-				"maybe-missing": "default",
-				"osb_context": map[string]interface{}{},
+				"location":            "nz",
+				"name":                "name-nz",
+				"maybe-missing":       "default",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},
@@ -716,10 +716,10 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 			DefaultOverride:   `{"name":"foo-${location}"}`, // 5
 			GlobalDefaults:    "{}",
 			ExpectedContext: map[string]interface{}{
-				"location":      "us",
-				"name":          "foo-${location}",
-				"maybe-missing": "default",
-				"osb_context": map[string]interface{}{},
+				"location":            "us",
+				"name":                "foo-${location}",
+				"maybe-missing":       "default",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},
@@ -734,10 +734,10 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 			DefaultOverride:    "{}",                                     // 5
 			GlobalDefaults:     `{"location":"az"}`,                      // 6
 			ExpectedContext: map[string]interface{}{
-				"location":      "eu",
-				"name":          "name-eu",
-				"maybe-missing": "default",
-				"osb_context": map[string]interface{}{},
+				"location":            "eu",
+				"name":                "name-eu",
+				"maybe-missing":       "default",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},
@@ -748,10 +748,10 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 			DefaultOverride:    "{}",                     // 5
 			GlobalDefaults:     `{"location":"az"}`,      // 6
 			ExpectedContext: map[string]interface{}{
-				"location":      "az",
-				"name":          "name-az",
-				"maybe-missing": "default",
-				"osb_context": map[string]interface{}{},
+				"location":            "az",
+				"name":                "name-az",
+				"maybe-missing":       "default",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},
@@ -762,10 +762,10 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 			DefaultOverride:    "{}",                     // 5
 			GlobalDefaults:     `{"location","az"}`,      // 6
 			ExpectedContext: map[string]interface{}{
-				"location":      "az",
-				"name":          "name-az",
-				"maybe-missing": "default",
-				"osb_context": map[string]interface{}{},
+				"location":            "az",
+				"name":                "name-az",
+				"maybe-missing":       "default",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 			ExpectedError: fmt.Errorf("Failed unmarshaling config value provision.defaults"),
@@ -774,10 +774,10 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 			ServiceProperties: map[string]interface{}{},           // 2
 			ProvisionDetails:  `{"location": "eu", "name":"foo"}`, // 5
 			ExpectedContext: map[string]interface{}{
-				"location":      "eu",
-				"name":          "foo",
-				"maybe-missing": "default",
-				"osb_context": map[string]interface{}{},
+				"location":            "eu",
+				"name":                "foo",
+				"maybe-missing":       "default",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},
@@ -786,10 +786,10 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 			UserParams:        `{"name":"update"}`,                // 4
 			ProvisionDetails:  `{"location": "eu", "name":"foo"}`, // 5
 			ExpectedContext: map[string]interface{}{
-				"location":      "eu",
-				"name":          "update",
-				"maybe-missing": "default",
-				"osb_context": map[string]interface{}{},
+				"location":            "eu",
+				"name":                "update",
+				"maybe-missing":       "default",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},
@@ -880,48 +880,48 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		UserParams      string
-		DefaultOverride string
-		BindOverrides   map[string]interface{}
-		ExpectedError   error
-		ExpectedContext map[string]interface{}
-		InstanceVars    string
-		RawContext string
+		UserParams          string
+		DefaultOverride     string
+		BindOverrides       map[string]interface{}
+		ExpectedError       error
+		ExpectedContext     map[string]interface{}
+		InstanceVars        string
+		RawContext          string
 		OriginatingIdentity map[string]interface{}
 	}{
 		"empty": {
 			UserParams:   "",
 			InstanceVars: `{"foo":""}`,
 			ExpectedContext: map[string]interface{}{
-				"location":     "us",
-				"name":         "name-us",
-				"instance-foo": "",
-				"service-prop": "operator-set",
-				"osb_context": map[string]interface{}{},
+				"location":            "us",
+				"name":                "name-us",
+				"instance-foo":        "",
+				"service-prop":        "operator-set",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},
 		"includes request context information": {
-			UserParams:        "",
-			RawContext:  `{"platform": "cloudfoundry", "organization_name": "acceptance"}`,
-			OriginatingIdentity:  map[string]interface{}{
+			UserParams: "",
+			RawContext: `{"platform": "cloudfoundry", "organization_name": "acceptance"}`,
+			OriginatingIdentity: map[string]interface{}{
 				"platform": "cloudfoundry",
 				"value": map[string]string{
 					"user_id": "683ea748-3092-4ff4-b656-39cacc4d5360",
 				}},
 			InstanceVars: `{"foo":""}`,
 			ExpectedContext: map[string]interface{}{
-				"location":      "us",
-				"name":          "name-us",
+				"location":     "us",
+				"name":         "name-us",
 				"instance-foo": "",
 				"service-prop": "operator-set",
 				"osb_context": map[string]interface{}{
-					"platform": "cloudfoundry",
+					"platform":          "cloudfoundry",
 					"organization_name": "acceptance",
 				},
 				"originatingIdentity": map[string]interface{}{
 					"platform": "cloudfoundry",
-					"value": map[string]interface{}{"user_id": "683ea748-3092-4ff4-b656-39cacc4d5360"},
+					"value":    map[string]interface{}{"user_id": "683ea748-3092-4ff4-b656-39cacc4d5360"},
 				},
 			},
 		},
@@ -929,11 +929,11 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 			UserParams:   `{"location": "averylonglocation"}`,
 			InstanceVars: `{"foo":"default"}`,
 			ExpectedContext: map[string]interface{}{
-				"location":     "averylongl",
-				"name":         "name-averylonglocation",
-				"instance-foo": "default",
-				"service-prop": "operator-set",
-				"osb_context": map[string]interface{}{},
+				"location":            "averylongl",
+				"name":                "name-averylonglocation",
+				"instance-foo":        "default",
+				"service-prop":        "operator-set",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},
@@ -941,11 +941,11 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 			UserParams:   `{"location": "eu", "name":"foo"}`,
 			InstanceVars: `{"foo":"default"}`,
 			ExpectedContext: map[string]interface{}{
-				"location":     "eu",
-				"name":         "foo",
-				"instance-foo": "default",
-				"service-prop": "operator-set",
-				"osb_context": map[string]interface{}{},
+				"location":            "eu",
+				"name":                "foo",
+				"instance-foo":        "default",
+				"service-prop":        "operator-set",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},
@@ -954,11 +954,11 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 			InstanceVars:    `{"foo":"default"}`,
 			DefaultOverride: `{"location":"eu"}`,
 			ExpectedContext: map[string]interface{}{
-				"location":     "eu",
-				"name":         "name-eu",
-				"instance-foo": "default",
-				"service-prop": "operator-set",
-				"osb_context": map[string]interface{}{},
+				"location":            "eu",
+				"name":                "name-eu",
+				"instance-foo":        "default",
+				"service-prop":        "operator-set",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},
@@ -967,13 +967,12 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 			InstanceVars:    `{"foo":"default"}`,
 			DefaultOverride: `{"location":"eu"}`,
 			ExpectedContext: map[string]interface{}{
-				"location":     "nz",
-				"name":         "name-nz",
-				"instance-foo": "default",
-				"service-prop": "operator-set",
-				"osb_context": map[string]interface{}{},
+				"location":            "nz",
+				"name":                "name-nz",
+				"instance-foo":        "default",
+				"service-prop":        "operator-set",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
-
 			},
 		},
 		"operator defaults are not evaluated": {
@@ -981,11 +980,11 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 			InstanceVars:    `{"foo":"default"}`,
 			DefaultOverride: `{"name":"foo-${location}"}`,
 			ExpectedContext: map[string]interface{}{
-				"location":     "us",
-				"name":         "foo-${location}",
-				"instance-foo": "default",
-				"service-prop": "operator-set",
-				"osb_context": map[string]interface{}{},
+				"location":            "us",
+				"name":                "foo-${location}",
+				"instance-foo":        "default",
+				"service-prop":        "operator-set",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},
@@ -993,11 +992,11 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 			UserParams:   `{"location":"us"}`,
 			InstanceVars: `{"foo":"bar"}`,
 			ExpectedContext: map[string]interface{}{
-				"location":     "us",
-				"name":         "name-us",
-				"instance-foo": "bar",
-				"service-prop": "operator-set",
-				"osb_context": map[string]interface{}{},
+				"location":            "us",
+				"name":                "name-us",
+				"instance-foo":        "bar",
+				"service-prop":        "operator-set",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},
@@ -1011,11 +1010,11 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 			InstanceVars:  `{"foo":"default"}`,
 			BindOverrides: map[string]interface{}{"location": "eu"},
 			ExpectedContext: map[string]interface{}{
-				"location":     "eu",
-				"name":         "name-eu",
-				"instance-foo": "default",
-				"service-prop": "operator-set",
-				"osb_context": map[string]interface{}{},
+				"location":            "eu",
+				"name":                "name-eu",
+				"instance-foo":        "default",
+				"service-prop":        "operator-set",
+				"osb_context":         map[string]interface{}{},
 				"originatingIdentity": map[string]interface{}{},
 			},
 		},

--- a/pkg/broker/service_definition.go
+++ b/pkg/broker/service_definition.go
@@ -402,14 +402,20 @@ func (svc *ServiceDefinition) variables(constants map[string]interface{},
 	return buildAndValidate(builder, svc.ProvisionInputVariables)
 }
 
-func (svc *ServiceDefinition) ProvisionVariables(instanceId string, details brokerapi.ProvisionDetails, plan ServicePlan) (*varcontext.VarContext, error) {
+func (svc *ServiceDefinition) ProvisionVariables(instanceId string, details brokerapi.ProvisionDetails, plan ServicePlan, originatingIdentity map[string]interface{}) (*varcontext.VarContext, error) {
+	rawContextMap := map[string]interface{}{}
+	json.Unmarshal(details.GetRawContext(), &rawContextMap)
+
 	// The namespaces of these values roughly align with the OSB spec.
 	constants := map[string]interface{}{
 		"request.plan_id":        details.PlanID,
 		"request.service_id":     details.ServiceID,
 		"request.instance_id":    instanceId,
 		"request.default_labels": utils.ExtractDefaultProvisionLabels(instanceId, details),
+		"request.context": rawContextMap,
+		"request.x_broker_api_originating_identity": originatingIdentity,
 	}
+
 	return svc.variables(constants, details.GetRawParameters(), json.RawMessage("{}"), plan)
 }
 

--- a/pkg/broker/service_definition.go
+++ b/pkg/broker/service_definition.go
@@ -405,11 +405,11 @@ func (svc *ServiceDefinition) variables(constants map[string]interface{},
 func (svc *ServiceDefinition) ProvisionVariables(instanceId string, details brokerapi.ProvisionDetails, plan ServicePlan, originatingIdentity map[string]interface{}) (*varcontext.VarContext, error) {
 	// The namespaces of these values roughly align with the OSB spec.
 	constants := map[string]interface{}{
-		"request.plan_id":        details.PlanID,
-		"request.service_id":     details.ServiceID,
-		"request.instance_id":    instanceId,
-		"request.default_labels": utils.ExtractDefaultProvisionLabels(instanceId, details),
-		"request.context": unmarshalJsonToMap(details.GetRawContext()),
+		"request.plan_id":                           details.PlanID,
+		"request.service_id":                        details.ServiceID,
+		"request.instance_id":                       instanceId,
+		"request.default_labels":                    utils.ExtractDefaultProvisionLabels(instanceId, details),
+		"request.context":                           unmarshalJsonToMap(details.GetRawContext()),
 		"request.x_broker_api_originating_identity": originatingIdentity,
 	}
 
@@ -462,7 +462,7 @@ func (svc *ServiceDefinition) BindVariables(instance models.ServiceInstanceDetai
 		// specified in the URL
 		"request.binding_id":  bindingID,
 		"request.instance_id": instance.ID,
-		"request.context": unmarshalJsonToMap(details.GetRawContext()),
+		"request.context":     unmarshalJsonToMap(details.GetRawContext()),
 
 		// specified in the request body
 		// Note: the value in instance is considered the official record so values
@@ -476,7 +476,6 @@ func (svc *ServiceDefinition) BindVariables(instance models.ServiceInstanceDetai
 		// specified by the existing instance
 		"instance.name":    instance.Name,
 		"instance.details": otherDetails,
-
 	}
 
 	builder := varcontext.Builder().

--- a/pkg/providers/builtin/storage/definition.go
+++ b/pkg/providers/builtin/storage/definition.go
@@ -211,7 +211,9 @@ func ServiceDefinition() *broker.ServiceDefinition {
 				},
 			},
 		},
-		BindComputedVariables: accountmanagers.ServiceAccountBindComputedVariables(),
+		BindComputedVariables: append(
+			accountmanagers.ServiceAccountBindComputedVariables(),
+			varcontext.DefaultVariable{Name: "originatingIdentity", Default: "${json.marshal(request.x_broker_api_originating_identity)}", Overwrite: true}),
 		ProviderBuilder: func(logger lager.Logger) broker.ServiceProvider {
 			bb := base.NewBrokerBase(os.Getenv("GOOGLE_CLOUD_PROJECT"), logger)
 			return &StorageBroker{BrokerBase: bb}

--- a/pkg/providers/builtin/storage/definition.go
+++ b/pkg/providers/builtin/storage/definition.go
@@ -136,6 +136,7 @@ func ServiceDefinition() *broker.ServiceDefinition {
 		},
 		ProvisionComputedVariables: []varcontext.DefaultVariable{
 			{Name: "labels", Default: "${json.marshal(request.default_labels)}", Overwrite: true},
+			{Name: "originatingIdentity", Default: "${json.marshal(request.x_broker_api_originating_identity)}", Overwrite: true},
 		},
 		DefaultRoleWhitelist: roleWhitelist,
 		BindInputVariables:   accountmanagers.ServiceAccountWhitelistWithDefault(roleWhitelist, "storage.objectAdmin"),

--- a/utils/request/request_parser.go
+++ b/utils/request/request_parser.go
@@ -1,0 +1,48 @@
+package request
+
+import (
+	"context"
+	b64 "encoding/base64"
+	"encoding/json"
+	"strings"
+)
+
+func DecodeOriginatingIdentityHeader(ctx context.Context) map[string]interface{} {
+	var originatingIdentityMap map[string]interface{}
+
+	originatingIdentityHeader := ctx.Value("originatingIdentity")
+	if originatingIdentityHeader != nil {
+		if headerAsString, ok := originatingIdentityHeader.(string); ok {
+			platform, value := parseHeader(headerAsString)
+			if value != "" {
+				if valueMap := unmarshallBase64JSON(value); valueMap != nil {
+					originatingIdentityMap = map[string]interface{}{
+						"platform": platform,
+						"value":    valueMap,
+					}
+				}
+			}
+		}
+	}
+
+	return originatingIdentityMap
+}
+
+func unmarshallBase64JSON(input string) ( result map[string]interface{} ) {
+	value, err := b64.StdEncoding.DecodeString(input)
+	if err != nil {
+		return nil
+	}
+	if err := json.Unmarshal(value, &result); err != nil {
+		return nil
+	}
+	return
+}
+
+func parseHeader(input string) (name, value string) {
+	headerParts := strings.Split(strings.TrimSpace(input), " ")
+	if len(headerParts) != 2 {
+		return "", ""
+	}
+	return headerParts[0], headerParts[1]
+}

--- a/utils/request/request_parser_test.go
+++ b/utils/request/request_parser_test.go
@@ -1,0 +1,62 @@
+package request_test
+
+import (
+	"context"
+	b64 "encoding/base64"
+	"fmt"
+	"github.com/cloudfoundry-incubator/cloud-service-broker/utils/request"
+	"reflect"
+	"testing"
+)
+
+func TestDecodeOriginatingIdentityHeader(t *testing.T) {
+	cases := []struct {
+		name string
+		ctx context.Context
+		expected map[string]interface{}
+	}{
+		{
+			name:     "good-header",
+			ctx:  context.WithValue(context.Background(), "originatingIdentity", "cloudfoundry eyANCiAgInVzZXJfaWQiOiAiNjgzZWE3NDgtMzA5Mi00ZmY0LWI2NTYtMzljYWNjNGQ1MzYwIg0KfQ==" ),
+			expected: map[string]interface{}{
+				"platform": "cloudfoundry",
+				"value": map[string]interface{}{
+					"user_id": "683ea748-3092-4ff4-b656-39cacc4d5360",
+				},
+			},
+		},
+		{
+			name:     "no header",
+			ctx:  context.Background(),
+			expected: nil,
+		},
+		{
+			name:     "wrong number of elements in header",
+			ctx:  context.WithValue(context.Background(), "originatingIdentity", "eyANCiAgInVzZXJfaWQiOiAiNjgzZWE3NDgtMzA5Mi00ZmY0LWI2NTYtMzljYWNjNGQ1MzYwIg0KfQ==" ),
+			expected: nil,
+		},
+		{
+			name:     "non encoded value",
+			ctx:  context.WithValue(context.Background(), "originatingIdentity", "cloudfoundry { \"user_id\": \"683ea748-3092-4ff4-b656-39cacc4d5360\" }" ),
+			expected: nil,
+		},
+		{
+			name:     "non json value",
+			ctx:  context.WithValue(context.Background(), "originatingIdentity", fmt.Sprintf("cloudfoundry %s", b64.StdEncoding.EncodeToString([]byte("not json"))) ),
+			expected: nil,
+		},
+		{
+			name:     "header is not a string",
+			ctx:  context.WithValue(context.Background(), "originatingIdentity", 111 ),
+			expected: nil,
+		},
+
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if actual := request.DecodeOriginatingIdentityHeader(tc.ctx); !reflect.DeepEqual(actual, tc.expected) {
+				t.Errorf("DecodeOriginatingIdentityHeader() = %v, expected %v", actual, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
[#177115261](https://www.pivotaltracker.com/story/show/177115261)

Implements https://github.com/cloudfoundry-incubator/cloud-service-broker/issues/138