### PR TITLE
chore: examples should send unique ID in each request

### DIFF
--- a/brokerapi/brokers/service_broker.go
+++ b/brokerapi/brokers/service_broker.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cloudfoundry-incubator/cloud-service-broker/db_service/models"
 	"github.com/cloudfoundry-incubator/cloud-service-broker/pkg/broker"
 	"github.com/cloudfoundry-incubator/cloud-service-broker/pkg/credstore"
+	"github.com/cloudfoundry-incubator/cloud-service-broker/utils/correlation"
 	"github.com/cloudfoundry-incubator/cloud-service-broker/utils/request"
 	"github.com/pivotal-cf/brokerapi/v7"
 )
@@ -92,7 +93,7 @@ func (broker *ServiceBroker) getDefinitionAndProvider(serviceId string) (*broker
 // Provision creates a new instance of a service.
 // It is bound to the `PUT /v2/service_instances/:instance_id` endpoint and can be called using the `cf create-service` command.
 func (broker *ServiceBroker) Provision(ctx context.Context, instanceID string, details brokerapi.ProvisionDetails, clientSupportsAsync bool) (brokerapi.ProvisionedServiceSpec, error) {
-	broker.Logger.Info("Provisioning", lager.Data{
+	broker.Logger.Info("Provisioning", correlation.ID(ctx), lager.Data{
 		"instanceId":         instanceID,
 		"accepts_incomplete": clientSupportsAsync,
 		"details":            details,

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -18,11 +18,11 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/spf13/cobra"
-
 	"github.com/cloudfoundry-incubator/cloud-service-broker/pkg/client"
 	"github.com/cloudfoundry-incubator/cloud-service-broker/pkg/server"
 	"github.com/cloudfoundry-incubator/cloud-service-broker/utils"
+	"github.com/pborman/uuid"
+	"github.com/spf13/cobra"
 )
 
 var (
@@ -85,31 +85,31 @@ user-defined plans.
 	rootCmd.AddCommand(clientCmd)
 
 	clientCatalogCmd := newClientCommand("catalog", "Show the service catalog", func(client *client.Client) *client.BrokerResponse {
-		return client.Catalog()
+		return client.Catalog(uuid.New())
 	})
 
 	provisionCmd := newClientCommand("provision", "Provision a service", func(client *client.Client) *client.BrokerResponse {
-		return client.Provision(instanceId, serviceId, planId, json.RawMessage(parametersJson))
+		return client.Provision(instanceId, serviceId, planId, uuid.New(), json.RawMessage(parametersJson))
 	})
 
 	deprovisionCmd := newClientCommand("deprovision", "Deprovision a service", func(client *client.Client) *client.BrokerResponse {
-		return client.Deprovision(instanceId, serviceId, planId)
+		return client.Deprovision(instanceId, serviceId, planId, uuid.New())
 	})
 
 	bindCmd := newClientCommand("bind", "Bind to a service", func(client *client.Client) *client.BrokerResponse {
-		return client.Bind(instanceId, bindingId, serviceId, planId, json.RawMessage(parametersJson))
+		return client.Bind(instanceId, bindingId, serviceId, planId, uuid.New(), json.RawMessage(parametersJson))
 	})
 
 	unbindCmd := newClientCommand("unbind", "Unbind a service", func(client *client.Client) *client.BrokerResponse {
-		return client.Unbind(instanceId, bindingId, serviceId, planId)
+		return client.Unbind(instanceId, bindingId, serviceId, planId, uuid.New())
 	})
 
 	lastCmd := newClientCommand("last", "Get the status of the last operation", func(client *client.Client) *client.BrokerResponse {
-		return client.LastOperation(instanceId)
+		return client.LastOperation(instanceId, uuid.New())
 	})
 
 	updateCmd := newClientCommand("update", "Update the instance details", func(client *client.Client) *client.BrokerResponse {
-		return client.Update(instanceId, serviceId, planId, json.RawMessage(parametersJson))
+		return client.Update(instanceId, serviceId, planId, uuid.New(), json.RawMessage(parametersJson))
 	})
 
 	examplesCmd := &cobra.Command{

--- a/pkg/providers/tf/provider.go
+++ b/pkg/providers/tf/provider.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cloudfoundry-incubator/cloud-service-broker/pkg/providers/builtin/base"
 	"github.com/cloudfoundry-incubator/cloud-service-broker/pkg/providers/tf/wrapper"
 	"github.com/cloudfoundry-incubator/cloud-service-broker/pkg/varcontext"
+	"github.com/cloudfoundry-incubator/cloud-service-broker/utils/correlation"
 	"github.com/pivotal-cf/brokerapi/v7"
 )
 
@@ -47,7 +48,7 @@ type terraformProvider struct {
 // Provision creates the necessary resources that an instance of this service
 // needs to operate.
 func (provider *terraformProvider) Provision(ctx context.Context, provisionContext *varcontext.VarContext) (models.ServiceInstanceDetails, error) {
-	provider.logger.Debug("terraform-provision", lager.Data{
+	provider.logger.Debug("terraform-provision", correlation.ID(ctx), lager.Data{
 		"context": provisionContext.ToMap(),
 	})
 

--- a/utils/correlation/correlation.go
+++ b/utils/correlation/correlation.go
@@ -1,0 +1,22 @@
+package correlation
+
+import (
+	"context"
+
+	"code.cloudfoundry.org/lager"
+	"github.com/pivotal-cf/brokerapi/v7/middlewares"
+)
+
+func ID(ctx context.Context) lager.Data {
+	result := make(lager.Data)
+	if cid, ok := ctx.Value(middlewares.CorrelationIDKey).(string); ok {
+		result["correlation-id"] = cid
+	}
+
+	// When brokerapi supports the request ID:
+	//if rid, ok := ctx.Value(middlewares.RequestIDKey).(string); ok {
+	//	result["request-id"] = rid
+	//}
+
+	return result
+}

--- a/utils/correlation/correlation_suite_test.go
+++ b/utils/correlation/correlation_suite_test.go
@@ -1,0 +1,13 @@
+package correlation_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCorrelation(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils Correlation Suite")
+}

--- a/utils/correlation/correlation_test.go
+++ b/utils/correlation/correlation_test.go
@@ -1,0 +1,31 @@
+package correlation_test
+
+import (
+	"context"
+
+	"github.com/cloudfoundry-incubator/cloud-service-broker/utils/correlation"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pivotal-cf/brokerapi/v7/middlewares"
+)
+
+var _ = Describe("Correlation", func() {
+	When("there is a correlation ID in the context", func() {
+		It("adds it to the logger data", func() {
+			const id = "417a8ca4-994b-11eb-a555-a30bdd8a2a34"
+			ctx := context.WithValue(context.TODO(), middlewares.CorrelationIDKey, id)
+
+			data := correlation.ID(ctx)
+
+			Expect(data).To(HaveKeyWithValue("correlation-id", id))
+			Expect(data).To(HaveLen(1))
+		})
+	})
+
+	When("the context is empty", func() {
+		It("returns an empty data object", func() {
+			data := correlation.ID(context.TODO())
+			Expect(data).To(BeEmpty())
+		})
+	})
+})


### PR DESCRIPTION
Each HTTP request from the examples now sends a unique value in the
'X-Correlation-ID' header and also logs the value so that each request
from the example test runner can in principle be correlated with events
in the broker logs.

The work to add request ID logging to all broker logs will be done in
[#177289977](https://www.pivotaltracker.com/story/show/177289977) but as
a proof of concept, a couple of logging statements in the Provision
request were updated so that they would log the correlation ID.

[#177317568](https://www.pivotaltracker.com/story/show/177317568)