### PR TITLE
chore: broker logs should show correlation ID

### DIFF
--- a/brokerapi/brokers/service_broker.go
+++ b/brokerapi/brokers/service_broker.go
@@ -171,7 +171,7 @@ func (broker *ServiceBroker) Provision(ctx context.Context, instanceID string, d
 // It is bound to the `DELETE /v2/service_instances/:instance_id` endpoint and can be called using the `cf delete-service` command.
 // If a deprovision is asynchronous, the returned DeprovisionServiceSpec will contain the operation ID for tracking its progress.
 func (broker *ServiceBroker) Deprovision(ctx context.Context, instanceID string, details brokerapi.DeprovisionDetails, clientSupportsAsync bool) (response brokerapi.DeprovisionServiceSpec, err error) {
-	broker.Logger.Info("Deprovisioning", lager.Data{
+	broker.Logger.Info("Deprovisioning", correlation.ID(ctx), lager.Data{
 		"instance_id":        instanceID,
 		"accepts_incomplete": clientSupportsAsync,
 		"details":            details,
@@ -246,7 +246,7 @@ func (broker *ServiceBroker) Deprovision(ctx context.Context, instanceID string,
 // Bind creates an account with credentials to access an instance of a service.
 // It is bound to the `PUT /v2/service_instances/:instance_id/service_bindings/:binding_id` endpoint and can be called using the `cf bind-service` command.
 func (broker *ServiceBroker) Bind(ctx context.Context, instanceID, bindingID string, details brokerapi.BindDetails, clientSupportsAsync bool) (brokerapi.Binding, error) {
-	broker.Logger.Info("Binding", lager.Data{
+	broker.Logger.Info("Binding", correlation.ID(ctx), lager.Data{
 		"instance_id": instanceID,
 		"binding_id":  bindingID,
 		"details":     details,
@@ -353,7 +353,7 @@ func getCredentialName(serviceName, bindingID string) string {
 //
 // NOTE: This functionality is not implemented.
 func (broker *ServiceBroker) GetBinding(ctx context.Context, instanceID, bindingID string) (brokerapi.GetBindingSpec, error) {
-	broker.Logger.Info("GetBinding", lager.Data{
+	broker.Logger.Info("GetBinding", correlation.ID(ctx), lager.Data{
 		"instance_id": instanceID,
 		"binding_id":  bindingID,
 	})
@@ -366,7 +366,7 @@ func (broker *ServiceBroker) GetBinding(ctx context.Context, instanceID, binding
 //
 // NOTE: This functionality is not implemented.
 func (broker *ServiceBroker) GetInstance(ctx context.Context, instanceID string) (brokerapi.GetInstanceDetailsSpec, error) {
-	broker.Logger.Info("GetInstance", lager.Data{
+	broker.Logger.Info("GetInstance", correlation.ID(ctx), lager.Data{
 		"instance_id": instanceID,
 	})
 
@@ -378,7 +378,7 @@ func (broker *ServiceBroker) GetInstance(ctx context.Context, instanceID string)
 //
 // NOTE: This functionality is not implemented.
 func (broker *ServiceBroker) LastBindingOperation(ctx context.Context, instanceID, bindingID string, details brokerapi.PollDetails) (brokerapi.LastOperation, error) {
-	broker.Logger.Info("LastBindingOperation", lager.Data{
+	broker.Logger.Info("LastBindingOperation", correlation.ID(ctx), lager.Data{
 		"instance_id":    instanceID,
 		"binding_id":     bindingID,
 		"plan_id":        details.PlanID,
@@ -392,7 +392,7 @@ func (broker *ServiceBroker) LastBindingOperation(ctx context.Context, instanceI
 // Unbind destroys an account and credentials with access to an instance of a service.
 // It is bound to the `DELETE /v2/service_instances/:instance_id/service_bindings/:binding_id` endpoint and can be called using the `cf unbind-service` command.
 func (broker *ServiceBroker) Unbind(ctx context.Context, instanceID, bindingID string, details brokerapi.UnbindDetails, asyncSupported bool) (brokerapi.UnbindSpec, error) {
-	broker.Logger.Info("Unbinding", lager.Data{
+	broker.Logger.Info("Unbinding", correlation.ID(ctx), lager.Data{
 		"instance_id": instanceID,
 		"binding_id":  bindingID,
 		"details":     details,
@@ -470,7 +470,7 @@ func (broker *ServiceBroker) Unbind(ctx context.Context, instanceID, bindingID s
 // It is bound to the `GET /v2/service_instances/:instance_id/last_operation` endpoint.
 // It is called by `cf create-service` or `cf delete-service` if the operation was asynchronous.
 func (broker *ServiceBroker) LastOperation(ctx context.Context, instanceID string, details brokerapi.PollDetails) (brokerapi.LastOperation, error) {
-	broker.Logger.Info("Last Operation", lager.Data{
+	broker.Logger.Info("Last Operation", correlation.ID(ctx), lager.Data{
 		"instance_id":    instanceID,
 		"plan_id":        details.PlanID,
 		"service_id":     details.ServiceID,
@@ -544,7 +544,7 @@ func (broker *ServiceBroker) updateStateOnOperationCompletion(ctx context.Contex
 // Update a service instance plan.
 // This functionality is not implemented and will return an error indicating that plan changes are not supported.
 func (broker *ServiceBroker) Update(ctx context.Context, instanceID string, details brokerapi.UpdateDetails, asyncAllowed bool) (response brokerapi.UpdateServiceSpec, err error) {
-	broker.Logger.Info("Updating", lager.Data{
+	broker.Logger.Info("Updating", correlation.ID(ctx), lager.Data{
 		"instance_id":        instanceID,
 		"accepts_incomplete": asyncAllowed,
 		"details":            details,

--- a/pkg/brokerpak/registrar_test.go
+++ b/pkg/brokerpak/registrar_test.go
@@ -15,6 +15,7 @@
 package brokerpak
 
 import (
+	"context"
 	"errors"
 	"os"
 	"os/exec"
@@ -62,7 +63,7 @@ func TestNewRegistrar(t *testing.T) {
 }
 
 func TestRegistrar_toDefinitions(t *testing.T) {
-	nopExecutor := func(c *exec.Cmd) (wrapper.ExecutionOutput, error) {
+	nopExecutor := func(context.Context, *exec.Cmd) (wrapper.ExecutionOutput, error) {
 		return wrapper.ExecutionOutput{}, nil
 	}
 

--- a/pkg/providers/builtin/account_managers/service_account_manager.go
+++ b/pkg/providers/builtin/account_managers/service_account_manager.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cloudfoundry-incubator/cloud-service-broker/pkg/broker"
 	"github.com/cloudfoundry-incubator/cloud-service-broker/pkg/validation"
 	"github.com/cloudfoundry-incubator/cloud-service-broker/pkg/varcontext"
-
+	"github.com/cloudfoundry-incubator/cloud-service-broker/utils/correlation"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/jwt"
 	cloudres "google.golang.org/api/cloudresourcemanager/v1"
@@ -56,7 +56,7 @@ func (sam *ServiceAccountManager) CreateCredentials(ctx context.Context, vc *var
 		return nil, err
 	}
 
-	sam.Logger.Info("create-service-account", lager.Data{
+	sam.Logger.Info("create-service-account", correlation.ID(ctx), lager.Data{
 		"role":                         role,
 		"service_account_name":         accountId,
 		"service_account_display_name": displayName,

--- a/pkg/providers/tf/provider.go
+++ b/pkg/providers/tf/provider.go
@@ -75,7 +75,7 @@ func (provider *terraformProvider) Provision(ctx context.Context, provisionConte
 
 // Update makes necessary updates to resources so they match new desired configuration
 func (provider *terraformProvider) Update(ctx context.Context, provisionContext *varcontext.VarContext) (models.ServiceInstanceDetails, error) {
-	provider.logger.Debug("update", lager.Data{
+	provider.logger.Debug("update", correlation.ID(ctx), lager.Data{
 		"context": provisionContext.ToMap(),
 	})
 
@@ -98,7 +98,7 @@ func (provider *terraformProvider) Update(ctx context.Context, provisionContext 
 
 // Bind creates a new backing Terraform job and executes it, waiting on the result.
 func (provider *terraformProvider) Bind(ctx context.Context, bindContext *varcontext.VarContext) (map[string]interface{}, error) {
-	provider.logger.Debug("terraform-bind", lager.Data{
+	provider.logger.Debug("terraform-bind", correlation.ID(ctx), lager.Data{
 		"context": bindContext.ToMap(),
 	})
 
@@ -194,7 +194,7 @@ func (provider *terraformProvider) create(ctx context.Context, vars *varcontext.
 // Unbind performs a terraform destroy on the binding.
 func (provider *terraformProvider) Unbind(ctx context.Context, instanceRecord models.ServiceInstanceDetails, bindRecord models.ServiceBindingCredentials, vc *varcontext.VarContext) error {
 	tfId := generateTfId(instanceRecord.ID, bindRecord.BindingId)
-	provider.logger.Debug("terraform-unbind", lager.Data{
+	provider.logger.Debug("terraform-unbind", correlation.ID(ctx), lager.Data{
 		"instance": instanceRecord.ID,
 		"binding":  bindRecord.ID,
 		"tfId":     tfId,
@@ -209,7 +209,7 @@ func (provider *terraformProvider) Unbind(ctx context.Context, instanceRecord mo
 
 // Deprovision performs a terraform destroy on the instance.
 func (provider *terraformProvider) Deprovision(ctx context.Context, instance models.ServiceInstanceDetails, details brokerapi.DeprovisionDetails, vc *varcontext.VarContext) (operationId *string, err error) {
-	provider.logger.Debug("terraform-deprovision", lager.Data{
+	provider.logger.Debug("terraform-deprovision", correlation.ID(ctx), lager.Data{
 		"instance": instance.ID,
 	})
 

--- a/pkg/providers/tf/wrapper/workspace_test.go
+++ b/pkg/providers/tf/wrapper/workspace_test.go
@@ -15,6 +15,7 @@
 package wrapper
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -33,19 +34,19 @@ func TestTerraformWorkspace_Invariants(t *testing.T) {
 		Exec func(ws *TerraformWorkspace)
 	}{
 		"validate": {Exec: func(ws *TerraformWorkspace) {
-			ws.Validate()
+			ws.Validate(context.TODO())
 		}},
 		"apply": {Exec: func(ws *TerraformWorkspace) {
-			ws.Apply()
+			ws.Apply(context.TODO())
 		}},
 		"destroy": {Exec: func(ws *TerraformWorkspace) {
-			ws.Destroy()
+			ws.Destroy(context.TODO())
 		}},
 		"import": {Exec: func(ws *TerraformWorkspace) {
-			ws.Import(map[string]string{})
+			ws.Import(context.TODO(), map[string]string{})
 		}},
 		"show": {Exec: func(ws *TerraformWorkspace) {
-			ws.Show()
+			ws.Show(context.TODO())
 		}}}
 
 	for tn, tc := range cases {
@@ -61,7 +62,7 @@ func TestTerraformWorkspace_Invariants(t *testing.T) {
 			// "running" tf
 			executorRan := false
 			cmdDir := ""
-			ws.Executor = func(cmd *exec.Cmd) (ExecutionOutput, error) {
+			ws.Executor = func(ctx context.Context, cmd *exec.Cmd) (ExecutionOutput, error) {
 				executorRan = true
 				cmdDir = cmd.Dir
 
@@ -118,19 +119,19 @@ func TestTerraformWorkspace_InvariantsFlat(t *testing.T) {
 		Exec func(ws *TerraformWorkspace)
 	}{
 		"validate": {Exec: func(ws *TerraformWorkspace) {
-			ws.Validate()
+			ws.Validate(context.TODO())
 		}},
 		"apply": {Exec: func(ws *TerraformWorkspace) {
-			ws.Apply()
+			ws.Apply(context.TODO())
 		}},
 		"destroy": {Exec: func(ws *TerraformWorkspace) {
-			ws.Destroy()
+			ws.Destroy(context.TODO())
 		}},
 		"import": {Exec: func(ws *TerraformWorkspace) {
-			ws.Import(map[string]string{})
+			ws.Import(context.TODO(), map[string]string{})
 		}},
 		"show": {Exec: func(ws *TerraformWorkspace) {
-			ws.Show()
+			ws.Show(context.TODO())
 		}}}
 
 	for tn, tc := range cases {
@@ -146,7 +147,7 @@ func TestTerraformWorkspace_InvariantsFlat(t *testing.T) {
 			// "running" tf
 			executorRan := false
 			cmdDir := ""
-			ws.Executor = func(cmd *exec.Cmd) (ExecutionOutput, error) {
+			ws.Executor = func(ctx context.Context, cmd *exec.Cmd) (ExecutionOutput, error) {
 				executorRan = true
 				cmdDir = cmd.Dir
 
@@ -234,12 +235,12 @@ func TestCustomTerraformExecutor(t *testing.T) {
 		t.Run(tn, func(t *testing.T) {
 			actual := exec.Command("!actual-never-got-called!")
 
-			executor := CustomTerraformExecutor(customBinary, customPlugins, func(c *exec.Cmd) (ExecutionOutput, error) {
+			executor := CustomTerraformExecutor(customBinary, customPlugins, func(ctx context.Context, c *exec.Cmd) (ExecutionOutput, error) {
 				actual = c
 				return ExecutionOutput{}, nil
 			})
 
-			executor(tc.Input)
+			executor(context.TODO(), tc.Input)
 
 			if actual.Path != tc.Expected.Path {
 				t.Errorf("path wasn't updated, expected: %q, actual: %q", tc.Expected.Path, actual.Path)
@@ -261,12 +262,12 @@ func TestCustomEnvironmentExecutor(t *testing.T) {
 	c.Env = []string{"ORIGINAL=value"}
 
 	actual := exec.Command("!actual-never-got-called!")
-	executor := CustomEnvironmentExecutor(map[string]string{"FOO": "bar"}, func(c *exec.Cmd) (ExecutionOutput, error) {
+	executor := CustomEnvironmentExecutor(map[string]string{"FOO": "bar"}, func(ctx context.Context, c *exec.Cmd) (ExecutionOutput, error) {
 		actual = c
 		return ExecutionOutput{}, nil
 	})
 
-	executor(c)
+	executor(context.TODO(), c)
 	expected := []string{"ORIGINAL=value", "FOO=bar"}
 
 	if !reflect.DeepEqual(expected, actual.Env) {


### PR DESCRIPTION
log lines relating to a request should show the correlation ID so that
they can be differentiated when there are concurrent requests

[#177289977](https://www.pivotaltracker.com/story/show/177289977)