### PR TITLE
tf localfiles support in brokerpak

### DIFF
--- a/pkg/brokerpak/manifest.go
+++ b/pkg/brokerpak/manifest.go
@@ -187,8 +187,16 @@ func (m *Manifest) packDefinitions(tmp, base string) error {
 			return fmt.Errorf("couldn't load provision template %s: %v", defn.ProvisionSettings.TemplateRef, err)
 		}
 
+		if err := defn.ProvisionSettings.LoadLocalFile(base); err != nil {
+			return fmt.Errorf("couldn't load provision local files: %v", err)
+		}
+
 		if err := defn.BindSettings.LoadTemplate(base); err != nil {
 			return fmt.Errorf("couldn't load bind template %s: %v", defn.BindSettings.TemplateRef, err)
+		}
+
+		if err := defn.BindSettings.LoadLocalFile(base); err != nil {
+			return fmt.Errorf("couldn't load bind local files: %v", err)
 		}
 
 		clearRefs(&defn.ProvisionSettings)

--- a/pkg/providers/tf/provider.go
+++ b/pkg/providers/tf/provider.go
@@ -155,7 +155,7 @@ func (provider *terraformProvider) importCreate(ctx context.Context, vars *varco
 		return "", err
 	}
 
-	workspace, err := wrapper.NewWorkspace(varsMap, "", action.Templates, parameterMappings, action.ImportParametersToDelete, addParams)
+	workspace, err := wrapper.NewWorkspace(varsMap, "", action.Templates, action.LocalFiles, parameterMappings, action.ImportParametersToDelete, addParams)
 	if err != nil {
 		return tfId, err
 	}
@@ -174,7 +174,7 @@ func (provider *terraformProvider) create(ctx context.Context, vars *varcontext.
 		return "", err
 	}
 
-	workspace, err := wrapper.NewWorkspace(vars.ToMap(), action.Template, action.Templates, []wrapper.ParameterMapping{}, []string{}, []wrapper.ParameterMapping{})
+	workspace, err := wrapper.NewWorkspace(vars.ToMap(), action.Template, action.Templates, action.LocalFiles, []wrapper.ParameterMapping{}, []string{}, []wrapper.ParameterMapping{})
 	if err != nil {
 		return tfId, err
 	}


### PR DESCRIPTION
Hi,

I submit you this pull request to support terraform localfiles in the brokerpak regarding the issue #114 .
The schema of the YAML services has been updated with a new action object "localfiles-refs"  as part of a provision or bind action.

```
provision:
  template_ref: terraform/myservice/main.tf
  localfile_refs:
    - terraform/myservice/foo.bar
    - terraform/myservice/listips.tmpl
    - terraform/myservice/libcreate.py
```

After that local files can be used in terraform files like below

```
locals {
  listips = templatefile("${path.module}/listips.tmpl", { port = 8080, ip_addrs = ["10.0.0.1", "10.0.0.2"] })
}

data "local_file" "foo" {
    filename = "${path.module}/foo.bar"
}

resource "null_resource" "api" {
    provisioner "local-exec" {
        command = "python3 ${path.module}/libcreate.py"
    }
}
```

Denis