### PR TITLE
encryption: encode before saving to database to avoid mysql encoding

### DIFF
--- a/brokerapi/brokers/brokers_test.go
+++ b/brokerapi/brokers/brokers_test.go
@@ -365,7 +365,7 @@ func TestServiceBroker_Provision(t *testing.T) {
 			Check: func(t *testing.T, broker *ServiceBroker, stub *serviceStub) {
 				req := stub.ProvisionDetails()
 				encryptor := fakes.FakeEncryptor{}
-				encryptor.EncryptReturns(nil, errors.New("error while encrypting"))
+				encryptor.EncryptReturns("", errors.New("error while encrypting"))
 				models.SetEncryptor(&encryptor)
 				_, err := broker.Provision(context.Background(), fakeInstanceId, req, true)
 				assertTrue(t, "errors should match", strings.Contains(err.Error(), "error while encrypting"))

--- a/db_service/models/db.go
+++ b/db_service/models/db.go
@@ -51,8 +51,8 @@ func ConfigureEncryption(encryptionKey string) Encryptor {
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -o fakes/fake_encryption.go . Encryptor
 type Encryptor interface {
-	Encrypt(plaintext []byte) ([]byte, error)
-	Decrypt(ciphertext []byte) ([]byte, error)
+	Encrypt(plaintext []byte) (string, error)
+	Decrypt(ciphertext string) ([]byte, error)
 }
 
 // ServiceBindingCredentials holds credentials returned to the users after
@@ -83,7 +83,7 @@ func (sbc ServiceBindingCredentials) GetOtherDetails(v interface{}) error {
 		return nil
 	}
 
-	decryptedDetails, err := encryptorInstance.Decrypt([]byte(sbc.OtherDetails))
+	decryptedDetails, err := encryptorInstance.Decrypt(sbc.OtherDetails)
 	if err != nil {
 		return err
 	}
@@ -118,7 +118,7 @@ func (si ServiceInstanceDetails) GetOtherDetails(v interface{}) error {
 		return nil
 	}
 
-	decryptedDetails, err := encryptorInstance.Decrypt([]byte(si.OtherDetails))
+	decryptedDetails, err := encryptorInstance.Decrypt(si.OtherDetails)
 	if err != nil {
 		return err
 	}
@@ -141,7 +141,7 @@ func (pr *ProvisionRequestDetails) SetRequestDetails(rawMessage json.RawMessage)
 }
 
 func (pr ProvisionRequestDetails) GetRequestDetails() (json.RawMessage, error) {
-	decryptedDetails, err := encryptorInstance.Decrypt([]byte(pr.RequestDetails))
+	decryptedDetails, err := encryptorInstance.Decrypt(pr.RequestDetails)
 	if err != nil {
 		return nil, err
 	}

--- a/db_service/models/db_test.go
+++ b/db_service/models/db_test.go
@@ -47,13 +47,15 @@ var _ = Describe("Db", func() {
 
 					credentials := models.ServiceBindingCredentials{}
 					err := credentials.SetOtherDetails(otherDetails)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred())
 
 					By("checking that it's no longer in plaintext")
-					Expect(credentials.OtherDetails).NotTo(Equal(expectedJSON))
+					Expect(credentials.OtherDetails).ToNot(Equal(expectedJSON))
 
 					By("being able to decrypt to get the value")
-					Expect(encryptor.Decrypt([]byte(credentials.OtherDetails))).To(Equal([]byte(expectedJSON)))
+					decrypted, err := encryptor.Decrypt(credentials.OtherDetails)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(string(decrypted)).To(Equal(expectedJSON))
 				})
 			})
 
@@ -67,12 +69,12 @@ var _ = Describe("Db", func() {
 					credentials.SetOtherDetails(otherDetails)
 
 					By("checking that it's encrypted")
-					Expect(credentials.OtherDetails).NotTo(ContainSubstring("some"))
+					Expect(credentials.OtherDetails).ToNot(ContainSubstring("some"))
 
 					By("decrypting that field")
 					var actualOtherDetails map[string]interface{}
 					err := credentials.GetOtherDetails(&actualOtherDetails)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred())
 
 					Expect(actualOtherDetails).To(HaveLen(1))
 					Expect(actualOtherDetails).To(HaveKeyWithValue("some", ConsistOf("json", "blob", "here")))
@@ -94,7 +96,7 @@ var _ = Describe("Db", func() {
 
 					credentials := models.ServiceBindingCredentials{}
 					err := credentials.SetOtherDetails(otherDetails)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred())
 
 					Expect(credentials.OtherDetails).To(Equal(`{"some":["json","blob","here"]}`))
 				})
@@ -102,7 +104,7 @@ var _ = Describe("Db", func() {
 				It("marshalls nil into json null", func() {
 					credentials := models.ServiceBindingCredentials{}
 					err := credentials.SetOtherDetails(nil)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred())
 
 					Expect(credentials.OtherDetails).To(Equal("null"))
 				})
@@ -127,7 +129,7 @@ var _ = Describe("Db", func() {
 					var actualOtherDetails map[string]interface{}
 					err := serviceBindingCredentials.GetOtherDetails(&actualOtherDetails)
 
-					Expect(err).NotTo(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(actualOtherDetails).To(HaveLen(1))
 					Expect(actualOtherDetails).To(HaveKeyWithValue("some", ConsistOf("json", "blob", "here")))
 				})
@@ -138,7 +140,7 @@ var _ = Describe("Db", func() {
 					var actualOtherDetails map[string]interface{}
 					err := serviceBindingCredentials.GetOtherDetails(&actualOtherDetails)
 
-					Expect(err).NotTo(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred())
 
 					Expect(actualOtherDetails).To(BeNil())
 				})
@@ -162,7 +164,7 @@ var _ = Describe("Db", func() {
 			Describe("SetOtherDetails", func() {
 				BeforeEach(func() {
 					fakeEncryptor := &fakes.FakeEncryptor{}
-					fakeEncryptor.EncryptReturns(nil, errors.New("fake encrypt error"))
+					fakeEncryptor.EncryptReturns("", errors.New("fake encrypt error"))
 
 					encryptor = fakeEncryptor
 					models.SetEncryptor(encryptor)
@@ -214,9 +216,10 @@ var _ = Describe("Db", func() {
 					details := models.ServiceInstanceDetails{}
 
 					err := details.SetOtherDetails(otherDetails)
+					Expect(err).ToNot(HaveOccurred())
 
-					Expect(err).NotTo(HaveOccurred())
-					decryptedDetails, _ := encryptor.Decrypt([]byte(details.OtherDetails))
+					decryptedDetails, err := encryptor.Decrypt(details.OtherDetails)
+					Expect(err).ToNot(HaveOccurred())
 					Expect(string(decryptedDetails)).To(Equal(`{"some":["json","blob","here"]}`))
 				})
 
@@ -225,8 +228,9 @@ var _ = Describe("Db", func() {
 
 					err := details.SetOtherDetails(nil)
 
-					Expect(err).NotTo(HaveOccurred())
-					decryptedDetails, _ := encryptor.Decrypt([]byte(details.OtherDetails))
+					Expect(err).ToNot(HaveOccurred())
+					decryptedDetails, err := encryptor.Decrypt(details.OtherDetails)
+					Expect(err).ToNot(HaveOccurred())
 					Expect(string(decryptedDetails)).To(Equal("null"))
 				})
 			})
@@ -241,7 +245,7 @@ var _ = Describe("Db", func() {
 					var actualOtherDetails map[string]interface{}
 					err := serviceInstanceDetails.GetOtherDetails(&actualOtherDetails)
 
-					Expect(err).NotTo(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred())
 
 					var arrayOfInterface []interface{}
 					arrayOfInterface = append(arrayOfInterface, "json", "blob", "here")
@@ -257,7 +261,7 @@ var _ = Describe("Db", func() {
 					var actualOtherDetails map[string]interface{}
 					err := serviceInstanceDetails.GetOtherDetails(&actualOtherDetails)
 
-					Expect(err).NotTo(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred())
 
 					Expect(actualOtherDetails).To(BeNil())
 				})
@@ -274,7 +278,7 @@ var _ = Describe("Db", func() {
 				var actualOtherDetails map[string]interface{}
 				err := serviceInstanceDetails.GetOtherDetails(&actualOtherDetails)
 
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
 
 				var arrayOfInterface []interface{}
 				arrayOfInterface = append(arrayOfInterface, "json", "blob", "here")
@@ -301,7 +305,7 @@ var _ = Describe("Db", func() {
 
 					err := details.SetOtherDetails(otherDetails)
 
-					Expect(err).NotTo(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(details.OtherDetails).To(Equal(`{"some":["json","blob","here"]}`))
 				})
 
@@ -310,7 +314,7 @@ var _ = Describe("Db", func() {
 
 					err := details.SetOtherDetails(nil)
 
-					Expect(err).NotTo(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(details.OtherDetails).To(Equal("null"))
 				})
 			})
@@ -324,7 +328,7 @@ var _ = Describe("Db", func() {
 					var actualOtherDetails map[string]interface{}
 					err := serviceInstanceDetails.GetOtherDetails(&actualOtherDetails)
 
-					Expect(err).NotTo(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred())
 
 					var arrayOfInterface []interface{}
 					arrayOfInterface = append(arrayOfInterface, "json", "blob", "here")
@@ -340,7 +344,7 @@ var _ = Describe("Db", func() {
 					var actualOtherDetails map[string]interface{}
 					err := serviceInstanceDetails.GetOtherDetails(&actualOtherDetails)
 
-					Expect(err).NotTo(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred())
 
 					Expect(actualOtherDetails).To(BeNil())
 				})
@@ -358,14 +362,14 @@ var _ = Describe("Db", func() {
 						F func()
 					}{F: func() {}})
 
-					Expect(err).ToNot(BeNil(), "Should have returned an error")
+					Expect(err).To(HaveOccurred(), "Should have returned an error")
 					Expect(details.OtherDetails).To(BeEmpty())
 				})
 
 				Context("When there are errors while encrypting", func() {
 					BeforeEach(func() {
 						fakeEncryptor := &fakes.FakeEncryptor{}
-						fakeEncryptor.EncryptReturns(nil, errors.New("some error"))
+						fakeEncryptor.EncryptReturns("", errors.New("some error"))
 
 						encryptor = fakeEncryptor
 						models.SetEncryptor(encryptor)
@@ -445,7 +449,8 @@ var _ = Describe("Db", func() {
 					rawMessage := []byte(`{"key":"value"}`)
 					details.SetRequestDetails(rawMessage)
 
-					decryptedDetails, _ := encryptor.Decrypt([]byte(details.RequestDetails))
+					decryptedDetails, err := encryptor.Decrypt(details.RequestDetails)
+					Expect(err).ToNot(HaveOccurred())
 					Expect(string(decryptedDetails)).To(Equal(`{"key":"value"}`))
 				})
 
@@ -454,7 +459,8 @@ var _ = Describe("Db", func() {
 
 					details.SetRequestDetails(nil)
 
-					decryptedDetails, _ := encryptor.Decrypt([]byte(details.RequestDetails))
+					decryptedDetails, err := encryptor.Decrypt(details.RequestDetails)
+					Expect(err).ToNot(HaveOccurred())
 					Expect(decryptedDetails).To(BeEmpty())
 				})
 
@@ -463,7 +469,8 @@ var _ = Describe("Db", func() {
 					var rawMessage []byte
 					details.SetRequestDetails(rawMessage)
 
-					decryptedDetails, _ := encryptor.Decrypt([]byte(details.RequestDetails))
+					decryptedDetails, err := encryptor.Decrypt(details.RequestDetails)
+					Expect(err).ToNot(HaveOccurred())
 					Expect(decryptedDetails).To(BeEmpty())
 				})
 			})
@@ -479,7 +486,7 @@ var _ = Describe("Db", func() {
 
 					rawMessage := json.RawMessage(`{"some":["json","blob","here"]}`)
 
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(details).To(Equal(rawMessage))
 				})
 			})
@@ -492,7 +499,7 @@ var _ = Describe("Db", func() {
 
 				actualDetails, err := details.GetRequestDetails()
 
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(actualDetails).To(Equal(rawMessage))
 			})
 		})
@@ -540,7 +547,7 @@ var _ = Describe("Db", func() {
 
 					rawMessage := json.RawMessage(`{"some":["json","blob","here"]}`)
 
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(details).To(Equal(rawMessage))
 				})
 			})
@@ -550,7 +557,7 @@ var _ = Describe("Db", func() {
 			Context("SetRequestDetails", func() {
 				BeforeEach(func() {
 					fakeEncryptor := &fakes.FakeEncryptor{}
-					fakeEncryptor.EncryptReturns(nil, errors.New("some error"))
+					fakeEncryptor.EncryptReturns("", errors.New("some error"))
 
 					encryptor = fakeEncryptor
 					models.SetEncryptor(encryptor)

--- a/db_service/models/fakes/fake_encryption.go
+++ b/db_service/models/fakes/fake_encryption.go
@@ -8,10 +8,10 @@ import (
 )
 
 type FakeEncryptor struct {
-	DecryptStub        func([]byte) ([]byte, error)
+	DecryptStub        func(string) ([]byte, error)
 	decryptMutex       sync.RWMutex
 	decryptArgsForCall []struct {
-		arg1 []byte
+		arg1 string
 	}
 	decryptReturns struct {
 		result1 []byte
@@ -21,37 +21,32 @@ type FakeEncryptor struct {
 		result1 []byte
 		result2 error
 	}
-	EncryptStub        func([]byte) ([]byte, error)
+	EncryptStub        func([]byte) (string, error)
 	encryptMutex       sync.RWMutex
 	encryptArgsForCall []struct {
 		arg1 []byte
 	}
 	encryptReturns struct {
-		result1 []byte
+		result1 string
 		result2 error
 	}
 	encryptReturnsOnCall map[int]struct {
-		result1 []byte
+		result1 string
 		result2 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeEncryptor) Decrypt(arg1 []byte) ([]byte, error) {
-	var arg1Copy []byte
-	if arg1 != nil {
-		arg1Copy = make([]byte, len(arg1))
-		copy(arg1Copy, arg1)
-	}
+func (fake *FakeEncryptor) Decrypt(arg1 string) ([]byte, error) {
 	fake.decryptMutex.Lock()
 	ret, specificReturn := fake.decryptReturnsOnCall[len(fake.decryptArgsForCall)]
 	fake.decryptArgsForCall = append(fake.decryptArgsForCall, struct {
-		arg1 []byte
-	}{arg1Copy})
+		arg1 string
+	}{arg1})
 	stub := fake.DecryptStub
 	fakeReturns := fake.decryptReturns
-	fake.recordInvocation("Decrypt", []interface{}{arg1Copy})
+	fake.recordInvocation("Decrypt", []interface{}{arg1})
 	fake.decryptMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -68,13 +63,13 @@ func (fake *FakeEncryptor) DecryptCallCount() int {
 	return len(fake.decryptArgsForCall)
 }
 
-func (fake *FakeEncryptor) DecryptCalls(stub func([]byte) ([]byte, error)) {
+func (fake *FakeEncryptor) DecryptCalls(stub func(string) ([]byte, error)) {
 	fake.decryptMutex.Lock()
 	defer fake.decryptMutex.Unlock()
 	fake.DecryptStub = stub
 }
 
-func (fake *FakeEncryptor) DecryptArgsForCall(i int) []byte {
+func (fake *FakeEncryptor) DecryptArgsForCall(i int) string {
 	fake.decryptMutex.RLock()
 	defer fake.decryptMutex.RUnlock()
 	argsForCall := fake.decryptArgsForCall[i]
@@ -107,7 +102,7 @@ func (fake *FakeEncryptor) DecryptReturnsOnCall(i int, result1 []byte, result2 e
 	}{result1, result2}
 }
 
-func (fake *FakeEncryptor) Encrypt(arg1 []byte) ([]byte, error) {
+func (fake *FakeEncryptor) Encrypt(arg1 []byte) (string, error) {
 	var arg1Copy []byte
 	if arg1 != nil {
 		arg1Copy = make([]byte, len(arg1))
@@ -137,7 +132,7 @@ func (fake *FakeEncryptor) EncryptCallCount() int {
 	return len(fake.encryptArgsForCall)
 }
 
-func (fake *FakeEncryptor) EncryptCalls(stub func([]byte) ([]byte, error)) {
+func (fake *FakeEncryptor) EncryptCalls(stub func([]byte) (string, error)) {
 	fake.encryptMutex.Lock()
 	defer fake.encryptMutex.Unlock()
 	fake.EncryptStub = stub
@@ -150,28 +145,28 @@ func (fake *FakeEncryptor) EncryptArgsForCall(i int) []byte {
 	return argsForCall.arg1
 }
 
-func (fake *FakeEncryptor) EncryptReturns(result1 []byte, result2 error) {
+func (fake *FakeEncryptor) EncryptReturns(result1 string, result2 error) {
 	fake.encryptMutex.Lock()
 	defer fake.encryptMutex.Unlock()
 	fake.EncryptStub = nil
 	fake.encryptReturns = struct {
-		result1 []byte
+		result1 string
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeEncryptor) EncryptReturnsOnCall(i int, result1 []byte, result2 error) {
+func (fake *FakeEncryptor) EncryptReturnsOnCall(i int, result1 string, result2 error) {
 	fake.encryptMutex.Lock()
 	defer fake.encryptMutex.Unlock()
 	fake.EncryptStub = nil
 	if fake.encryptReturnsOnCall == nil {
 		fake.encryptReturnsOnCall = make(map[int]struct {
-			result1 []byte
+			result1 string
 			result2 error
 		})
 	}
 	fake.encryptReturnsOnCall[i] = struct {
-		result1 []byte
+		result1 string
 		result2 error
 	}{result1, result2}
 }

--- a/internal/encryption/encryption.go
+++ b/internal/encryption/encryption.go
@@ -4,6 +4,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	b64 "encoding/base64"
 	"errors"
 	"io"
 )
@@ -16,31 +17,37 @@ func NewGCMEncryptor(key *[32]byte) GCMEncryptor {
 	return GCMEncryptor{Key: key}
 }
 
-func (d GCMEncryptor) Encrypt(plaintext []byte) (ciphertext []byte, err error) {
+func (d GCMEncryptor) Encrypt(plaintext []byte) (string, error) {
 	// Initialize an AES block cipher
 	block, err := aes.NewCipher(d.Key[:])
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	// Specify a GCM block cipher mode
 	gcm, err := cipher.NewGCM(block)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	// Generate a random nonce
 	nonce := make([]byte, gcm.NonceSize())
 	_, err = io.ReadFull(rand.Reader, nonce)
 	if err != nil {
+		return "", err
+	}
+
+	// Return the encrypted text appended to the nonce, encoded in b64
+	sealed := gcm.Seal(nonce, nonce, plaintext, nil)
+	return b64.StdEncoding.EncodeToString(sealed), nil
+}
+
+func (d GCMEncryptor) Decrypt(ciphertext string) ([]byte, error) {
+	decoded, err := b64.StdEncoding.DecodeString(ciphertext)
+	if err != nil {
 		return nil, err
 	}
 
-	// Return the encrypted text appended to the nonce
-	return gcm.Seal(nonce, nonce, plaintext, nil), nil
-}
-
-func (d GCMEncryptor) Decrypt(ciphertext []byte) (plaintext []byte, err error) {
 	// Initialize an AES block cipher
 	block, err := aes.NewCipher(d.Key[:])
 	if err != nil {
@@ -51,13 +58,13 @@ func (d GCMEncryptor) Decrypt(ciphertext []byte) (plaintext []byte, err error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(ciphertext) < gcm.NonceSize() {
+	if len(decoded) < gcm.NonceSize() {
 		return nil, errors.New("malformed ciphertext")
 	}
 	// The encrypted text comes after the nonce
 	return gcm.Open(nil,
-		ciphertext[:gcm.NonceSize()],
-		ciphertext[gcm.NonceSize():],
+		decoded[:gcm.NonceSize()],
+		decoded[gcm.NonceSize():],
 		nil,
 	)
 }
@@ -65,12 +72,12 @@ func (d GCMEncryptor) Decrypt(ciphertext []byte) (plaintext []byte, err error) {
 type NoopEncryptor struct {
 }
 
-func (d NoopEncryptor) Encrypt(plaintext []byte) (ciphertext []byte, err error) {
-	return plaintext, nil
+func (d NoopEncryptor) Encrypt(plaintext []byte) (string, error) {
+	return string(plaintext), nil
 }
 
-func (d NoopEncryptor) Decrypt(ciphertext []byte) (plaintext []byte, err error) {
-	return ciphertext, nil
+func (d NoopEncryptor) Decrypt(ciphertext string) ([]byte, error) {
+	return []byte(ciphertext), nil
 }
 
 func NewNoopEncryptor() NoopEncryptor {


### PR DESCRIPTION
restrictions

MySQL's utf8 permits only the Unicode characters that can be represented
with 3 bytes in UTF-8, Changing the encoding in the dabatase fixes it,
but it requires migrations and it is also database dependent.
Encoding to b64 makes it more straightforward.

[#178795926](https://www.pivotaltracker.com/story/show/178795926)