### PR TITLE
Validations for new password style

### DIFF
--- a/internal/encryption/parser/parser.go
+++ b/internal/encryption/parser/parser.go
@@ -1,0 +1,1 @@
+package configparser

--- a/internal/encryption/parser/parser.go
+++ b/internal/encryption/parser/parser.go
@@ -1,1 +1,88 @@
-package configparser
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/cloudfoundry-incubator/cloud-service-broker/pkg/validation"
+)
+
+type PasswordEntry struct {
+	Label   string
+	Secret  string
+	Primary bool
+}
+
+func Parse(input string) ([]PasswordEntry, error) {
+	if len(input) == 0 {
+		return nil, nil
+	}
+
+	var r receiver
+	if err := json.Unmarshal([]byte(input), &r); err != nil {
+		return nil, fmt.Errorf("password configuration JSON error: %w", err)
+	}
+
+	if len(r) == 0 {
+		return nil, nil
+	}
+
+	result := convert(r)
+
+	if err := validate(result); err != nil {
+		return nil, fmt.Errorf("password configuration error: %w", err)
+	}
+
+	return result, nil
+}
+
+type receiver []struct {
+	Label    string `json:"label"`
+	Primary  bool   `json:"primary"`
+	Password struct {
+		Secret string `json:"secret"`
+	} `json:"password"`
+}
+
+func convert(r receiver) []PasswordEntry {
+	var result []PasswordEntry
+	for _, p := range r {
+		result = append(result, PasswordEntry{
+			Label:   p.Label,
+			Secret:  p.Password.Secret,
+			Primary: p.Primary,
+		})
+	}
+
+	return result
+}
+
+func validate(passwordEntries []PasswordEntry) (errs *validation.FieldError) {
+	labels := make(map[string]struct{})
+	primaries := 0
+	for i, p := range passwordEntries {
+		if p.Primary {
+			primaries++
+		}
+		errs = errs.Also(
+			validation.ErrIfOutsideLength(p.Secret, "secret.password", 20, 1024).ViaIndex(i),
+			validation.ErrIfOutsideLength(p.Label, "label", 5, 20).ViaIndex(i),
+			validation.ErrIfDuplicate(p.Label, "label", labels).ViaIndex(i),
+		)
+	}
+
+	switch primaries {
+	case 0:
+		return errs.Also(&validation.FieldError{
+			Message: "expected exactly one primary, got none",
+			Paths:   []string{"[].primary"},
+		})
+	case 1:
+		return errs
+	default:
+		return errs.Also(&validation.FieldError{
+			Message: "expected exactly one primary, got multiple",
+			Paths:   []string{"[].primary"},
+		})
+	}
+}

--- a/internal/encryption/parser/parser_suite_test.go
+++ b/internal/encryption/parser/parser_suite_test.go
@@ -1,0 +1,13 @@
+package parser_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestParser(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Encryption Parser Suite")
+}

--- a/internal/encryption/parser/parser_test.go
+++ b/internal/encryption/parser/parser_test.go
@@ -1,0 +1,134 @@
+package parser_test
+
+import (
+	"strings"
+
+	"github.com/cloudfoundry-incubator/cloud-service-broker/internal/encryption/parser"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Parser", func() {
+	DescribeTable(
+		"correct",
+		func(input string, expected interface{}) {
+			output, err := parser.Parse(input)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(Equal(expected))
+		},
+		Entry(
+			"empty",
+			``,
+			[]parser.PasswordEntry(nil),
+		),
+		Entry(
+			"empty list",
+			`[]`,
+			[]parser.PasswordEntry(nil),
+		),
+		Entry(
+			"one with minimum lengths",
+			`[{"label":"five5","password":{"secret":"01234567890123456789"},"primary":true}]`,
+			[]parser.PasswordEntry{
+				{
+					Label:   "five5",
+					Secret:  "01234567890123456789",
+					Primary: true,
+				},
+			},
+		),
+		Entry(
+			"one with maximum lengths",
+			`[{"label":"01234567890123456789","password":{"secret":"`+strings.Repeat("a", 1024)+`"},"primary":true}]`,
+			[]parser.PasswordEntry{
+				{
+					Label:   "01234567890123456789",
+					Secret:  strings.Repeat("a", 1024),
+					Primary: true,
+				},
+			},
+		),
+		Entry(
+			"one with extra fields",
+			`[{"randomz":"extra","label":"barfoo","password":{"secret":"01234567890123456789"},"primary":true}]`,
+			[]parser.PasswordEntry{
+				{
+					Label:   "barfoo",
+					Secret:  "01234567890123456789",
+					Primary: true,
+				},
+			},
+		),
+		Entry(
+			"many",
+			`[{"label":"barfoo","password":{"secret":"veryverysecretpassword"},"primary":false},{"label":"barbaz","password":{"secret":"anotherveryverysecretpassword"}},{"label":"bazquz","password":{"secret":"yetanotherveryverysecretpassword"},"primary":true}]`,
+			[]parser.PasswordEntry{
+				{
+					Label:   "barfoo",
+					Secret:  "veryverysecretpassword",
+					Primary: false,
+				},
+				{
+					Label:   "barbaz",
+					Secret:  "anotherveryverysecretpassword",
+					Primary: false,
+				},
+				{
+					Label:   "bazquz",
+					Secret:  "yetanotherveryverysecretpassword",
+					Primary: true,
+				},
+			},
+		),
+	)
+
+	DescribeTable(
+		"errors",
+		func(input string, expected interface{}) {
+			output, err := parser.Parse(input)
+			Expect(output).To(BeEmpty())
+			Expect(err).To(MatchError(expected), err.Error())
+		},
+		Entry(
+			"bad JSON",
+			`[{"stuf"`,
+			`password configuration JSON error: unexpected end of JSON input`,
+		),
+		Entry(
+			"password length too short",
+			`[{"label":"barfoo","password":{"secret":"veryverysecretpassword"},"primary":false},{"label":"barbaz","password":{"secret":"anotherveryverysecretpassword"}},{"label":"bazquz","password":{"secret":"tooshort"},"primary":true}]`,
+			`password configuration error: expected value to be 20-1024 characters long, but got length 8: [2].secret.password`,
+		),
+		Entry(
+			"password length too long",
+			`[{"label":"barfoo","password":{"secret":"`+strings.Repeat("p", 2000)+`"},"primary":false},{"label":"barbaz","password":{"secret":"anotherveryverysecretpassword"}},{"label":"bazquz","password":{"secret":"yetanotherveryverysecretpassword"},"primary":true}]`,
+			`password configuration error: expected value to be 20-1024 characters long, but got length 2000: [0].secret.password`,
+		),
+		Entry(
+			"label length too short",
+			`[{"label":"barfoo","password":{"secret":"veryverysecretpassword"},"primary":false},{"label":"bar","password":{"secret":"anotherveryverysecretpassword"}},{"label":"bazquz","password":{"secret":"yetanotherveryverysecretpassword"},"primary":true}]`,
+			`password configuration error: expected value to be 5-20 characters long, but got length 3: [1].label`,
+		),
+		Entry(
+			"label length too long",
+			`[{"label":"012345678901234567890","password":{"secret":"veryverysecretpassword"},"primary":false},{"label":"barbaz","password":{"secret":"anotherveryverysecretpassword"}},{"label":"bazquz","password":{"secret":"yetanotherveryverysecretpassword"},"primary":true}]`,
+			`password configuration error: expected value to be 5-20 characters long, but got length 21: [0].label`,
+		),
+		Entry(
+			"label duplication",
+			`[{"label":"barfoo","password":{"secret":"veryverysecretpassword"},"primary":false},{"label":"barbaz","password":{"secret":"anotherveryverysecretpassword"}},{"label":"barfoo","password":{"secret":"yetanotherveryverysecretpassword"},"primary":true}]`,
+			`password configuration error: duplicated value, must be unique: barfoo: [2].label`,
+		),
+		Entry(
+			"no primary",
+			`[{"label":"barfoo","password":{"secret":"veryverysecretpassword"},"primary":false},{"label":"barbaz","password":{"secret":"anotherveryverysecretpassword"}},{"label":"bazquz","password":{"secret":"yetanotherveryverysecretpassword"},"primary":false}]`,
+			`password configuration error: expected exactly one primary, got none: [].primary`,
+		),
+		Entry(
+			"multiple primaries",
+			`[{"label":"barfoo","password":{"secret":"veryverysecretpassword"},"primary":true},{"label":"barbaz","password":{"secret":"anotherveryverysecretpassword"}},{"label":"bazquz","password":{"secret":"yetanotherveryverysecretpassword"},"primary":true}]`,
+			`password configuration error: expected exactly one primary, got multiple: [].primary`,
+		),
+	)
+})

--- a/pkg/broker/catalog.go
+++ b/pkg/broker/catalog.go
@@ -33,8 +33,8 @@ func (s *Service) Validate() (errs *validation.FieldError) {
 	for i, v := range s.Plans {
 		errs = errs.Also(
 			v.Validate().ViaFieldIndex("Plans", i),
-			validation.ErrIfDuplicate("Name", v.Name, names).ViaFieldIndex("Plans", i),
-			validation.ErrIfDuplicate("Id", v.ID, ids).ViaFieldIndex("Plans", i),
+			validation.ErrIfDuplicate(v.Name, "Name", names).ViaFieldIndex("Plans", i),
+			validation.ErrIfDuplicate(v.ID, "Id", ids).ViaFieldIndex("Plans", i),
 		)
 	}
 	return errs

--- a/pkg/broker/registry.go
+++ b/pkg/broker/registry.go
@@ -73,13 +73,13 @@ func (brokerRegistry BrokerRegistry) Validate() (errs *validation.FieldError) {
 	planIDs := make(map[string]struct{})
 	for i, s := range services {
 		errs = errs.Also(
-			validation.ErrIfDuplicate("Id", s.Id, serviceIDs).ViaFieldIndex("services", i),
-			validation.ErrIfDuplicate("Name", s.Name, serviceNames).ViaFieldIndex("services", i),
+			validation.ErrIfDuplicate(s.Id, "Id", serviceIDs).ViaFieldIndex("services", i),
+			validation.ErrIfDuplicate(s.Name, "Name", serviceNames).ViaFieldIndex("services", i),
 		)
 
 		for j, p := range s.Plans {
 			errs = errs.Also(
-				validation.ErrIfDuplicate("Id", p.ID, planIDs).ViaFieldIndex("Plans", j).ViaFieldIndex("services", i),
+				validation.ErrIfDuplicate(p.ID, "Id", planIDs).ViaFieldIndex("Plans", j).ViaFieldIndex("services", i),
 			)
 		}
 	}

--- a/pkg/broker/service_definition.go
+++ b/pkg/broker/service_definition.go
@@ -116,8 +116,8 @@ func (svc *ServiceDefinition) Validate() (errs *validation.FieldError) {
 	for i, v := range svc.Plans {
 		errs = errs.Also(
 			v.Validate().ViaFieldIndex("Plans", i),
-			validation.ErrIfDuplicate("Name", v.Name, names).ViaFieldIndex("Plans", i),
-			validation.ErrIfDuplicate("Id", v.ID, ids).ViaFieldIndex("Plans", i),
+			validation.ErrIfDuplicate(v.Name, "Name", names).ViaFieldIndex("Plans", i),
+			validation.ErrIfDuplicate(v.ID, "Id", ids).ViaFieldIndex("Plans", i),
 		)
 	}
 

--- a/pkg/providers/tf/definition.go
+++ b/pkg/providers/tf/definition.go
@@ -181,8 +181,8 @@ func (tfb *TfServiceDefinitionV1) Validate() (errs *validation.FieldError) {
 	for i, v := range tfb.Plans {
 		errs = errs.Also(
 			v.Validate().ViaFieldIndex("plans", i),
-			validation.ErrIfDuplicate("Name", v.Name, names).ViaFieldIndex("plans", i),
-			validation.ErrIfDuplicate("Id", v.Id, ids).ViaFieldIndex("plans", i),
+			validation.ErrIfDuplicate(v.Name, "Name", names).ViaFieldIndex("plans", i),
+			validation.ErrIfDuplicate(v.Id, "Id", ids).ViaFieldIndex("plans", i),
 		)
 	}
 
@@ -542,12 +542,12 @@ func (tfb TfCatalogDefinitionV1) Validate() (errs *validation.FieldError) {
 	for i, service := range tfb {
 		errs = errs.Also(
 			service.Validate().ViaFieldIndex("services", i),
-			validation.ErrIfDuplicate("Name", service.Name, names).ViaFieldIndex("services", i),
-			validation.ErrIfDuplicate("Id", service.Id, serviceIDs).ViaFieldIndex("services", i),
+			validation.ErrIfDuplicate(service.Name, "Name", names).ViaFieldIndex("services", i),
+			validation.ErrIfDuplicate(service.Id, "Id", serviceIDs).ViaFieldIndex("services", i),
 		)
 
 		for j, plan := range service.Plans {
-			errs = errs.Also(validation.ErrIfDuplicate("Id", plan.Id, planIDs)).ViaFieldIndex("plans", j).ViaFieldIndex("services", i)
+			errs = errs.Also(validation.ErrIfDuplicate(plan.Id, "Id", planIDs)).ViaFieldIndex("plans", j).ViaFieldIndex("services", i)
 		}
 	}
 

--- a/pkg/validation/field_error.go
+++ b/pkg/validation/field_error.go
@@ -362,6 +362,15 @@ func ErrOutOfBoundsValue(value, lower, upper interface{}, fieldPath string) *Fie
 	}
 }
 
+// ErrOutsideLength constructs a FieldError for a field that has received a
+// value that it outside of a length range
+func ErrOutsideLength(value, lower, upper int, fieldPath string) *FieldError {
+	return &FieldError{
+		Message: fmt.Sprintf("expected value to be %d-%d characters long, but got length %d", lower, upper, value),
+		Paths:   []string{fieldPath},
+	}
+}
+
 // ErrDuplicate constructs a FieldError for a field value that has been duplicated
 // when it should have been unique
 func ErrDuplicate(value string, fieldPaths ...string) *FieldError {

--- a/pkg/validation/field_error_test.go
+++ b/pkg/validation/field_error_test.go
@@ -243,6 +243,11 @@ Second: X, Y, Z`,
 		err:      ErrOutOfBoundsValue(1*time.Second, 2*time.Second, 5*time.Second, "timeout"),
 		prefixes: [][]string{{"spec"}},
 		want:     `expected 2s <= 1s <= 5s: spec.timeout`,
+	}, {
+		name:     "outside length",
+		err:      ErrOutsideLength(4, 1, 3, "my-field"),
+		prefixes: [][]string{{"spec"}},
+		want:     `expected value to be 1-3 characters long, but got length 4: spec.my-field`,
 	}}
 
 	for _, test := range tests {

--- a/pkg/validation/struct_validator.go
+++ b/pkg/validation/struct_validator.go
@@ -31,7 +31,7 @@ var (
 )
 
 // ErrIfNotHCL returns an error if the value is not valid HCL.
-func ErrIfNotHCL(value string, field string) *FieldError {
+func ErrIfNotHCL(value, field string) *FieldError {
 	parser := hclparse.NewParser()
 	if _, err := parser.ParseHCL([]byte(value), ""); err == nil {
 		return nil
@@ -56,7 +56,7 @@ func ErrIfNotJSON(value json.RawMessage, field string) *FieldError {
 }
 
 // ErrIfBlank returns an error if the value is a blank string.
-func ErrIfBlank(value string, field string) *FieldError {
+func ErrIfBlank(value, field string) *FieldError {
 	if value == "" {
 		return ErrMissingField(field)
 	}
@@ -74,24 +74,24 @@ func ErrIfNil(value interface{}, field string) *FieldError {
 }
 
 // ErrIfNotOSBName returns an error if the value is not a valid OSB name.
-func ErrIfNotOSBName(value string, field string) *FieldError {
+func ErrIfNotOSBName(value, field string) *FieldError {
 	return ErrIfNotMatch(value, osbNameRegex, field)
 }
 
 // ErrIfNotJSONSchemaType returns an error if the value is not a valid JSON
 // schema type.
-func ErrIfNotJSONSchemaType(value string, field string) *FieldError {
+func ErrIfNotJSONSchemaType(value, field string) *FieldError {
 	return ErrIfNotMatch(value, jsonSchemaTypeRegex, field)
 }
 
 // ErrIfNotTerraformIdentifier returns an error if the value is not a valid
 // Terraform identifier.
-func ErrIfNotTerraformIdentifier(value string, field string) *FieldError {
+func ErrIfNotTerraformIdentifier(value, field string) *FieldError {
 	return ErrIfNotMatch(value, terraformIdentifierRegex, field)
 }
 
 // ErrIfNotUUID returns an error if the value is not a valid UUID.
-func ErrIfNotUUID(value string, field string) *FieldError {
+func ErrIfNotUUID(value, field string) *FieldError {
 	if uuidRegex.MatchString(value) {
 		return nil
 	}
@@ -103,7 +103,7 @@ func ErrIfNotUUID(value string, field string) *FieldError {
 }
 
 // ErrIfNotURL returns an error if the value is not a valid URL.
-func ErrIfNotURL(value string, field string) *FieldError {
+func ErrIfNotURL(value, field string) *FieldError {
 	// Validaiton inspired by: github.com/go-playground/validator/baked_in.go
 	url, err := url.ParseRequestURI(value)
 	if err != nil || url.Scheme == "" {
@@ -135,7 +135,7 @@ func ErrMustMatch(value string, regex *regexp.Regexp, field string) *FieldError 
 
 // ErrIfDuplicate returns error when a value is duplicated when it should be unique.
 // State is stored in the cache which must be provided for every call in the set.
-func ErrIfDuplicate(field, value string, cache map[string]struct{}) *FieldError {
+func ErrIfDuplicate(value, field string, cache map[string]struct{}) *FieldError {
 	if _, dup := cache[value]; dup {
 		return ErrDuplicate(value, field)
 	}

--- a/pkg/validation/struct_validator.go
+++ b/pkg/validation/struct_validator.go
@@ -143,6 +143,16 @@ func ErrIfDuplicate(value, field string, cache map[string]struct{}) *FieldError 
 	return nil
 }
 
+// ErrIfOutsideLength returns an error if the length of the specified string is outside
+// of the specified length range
+func ErrIfOutsideLength(value, field string, min, max int) *FieldError {
+	l := len(value)
+	if l > max || l < min {
+		return ErrOutsideLength(l, min, max, field)
+	}
+	return nil
+}
+
 // Validatable indicates that a particular type may have its fields validated.
 type Validatable interface {
 	// Validate checks the validity of this types fields.
@@ -160,7 +170,7 @@ type Testable interface {
 	Errorf(format string, a ...interface{})
 }
 
-// Assert runs the validatae function and fails Testable.
+// Assert runs the validate function and fails Testable.
 func (vt *ValidatableTest) Assert(t Testable) {
 	actual := vt.Object.Validate()
 	expect := vt.Expect

--- a/pkg/validation/struct_validator_test.go
+++ b/pkg/validation/struct_validator_test.go
@@ -63,3 +63,17 @@ func ExampleErrIfNotJSON() {
 	// Output: Good is nil: true
 	// Bad: invalid JSON: my-field
 }
+
+func ExampleErrIfOutsideLength() {
+	fmt.Println("Good is within length:", ErrIfOutsideLength("four", "my-field", 2, 10) == nil)
+	fmt.Println("Good is at minimum:", ErrIfOutsideLength("four", "my-field", 4, 10) == nil)
+	fmt.Println("Good is at maximum:", ErrIfOutsideLength("four", "my-field", 1, 4) == nil)
+	fmt.Println("Bad is too short:", ErrIfOutsideLength("four", "my-field", 5, 10))
+	fmt.Println("Bad is too long:", ErrIfOutsideLength("four", "my-field", 1, 3))
+
+	// Output: Good is within length: true
+	// Good is at minimum: true
+	// Good is at maximum: true
+	// Bad is too short: expected value to be 5-10 characters long, but got length 4: my-field
+	// Bad is too long: expected value to be 1-3 characters long, but got length 4: my-field
+}


### PR DESCRIPTION
In future we plan to accept multiple encryption passwords with format:
```json
[
  {
    "label": "my-label",
    "primary": true,
    "password": {
      "secret": "fake-super-secret-password"
    }
  },
  {...}
]
```
The format is based on the output of the tile configuration

Based on PR #288 by @FelisiaM