### PR TITLE
chore: separate unit and integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ VERSION := $(or $(VERSION), dev)
 
 LDFLAGS="-X github.com/cloudfoundry-incubator/cloud-service-broker/utils.Version=$(VERSION)"
 
+PKG="github.com/cloudfoundry-incubator/cloud-service-broker"
+
 .PHONY: deps-go-binary
 deps-go-binary:
 ifeq ($(SKIP_GO_VERSION_CHECK),)
@@ -45,11 +47,15 @@ help: ## list Makefile targets
 ###### Test ###################################################################
 
 .PHONY: test
-test: download lint test-units ## run lint and unit tests
+test: download lint test-units test-integration ## run lint and unit tests
 
 .PHONY: test-units
 test-units: deps-go-binary ## run unit tests
-	$(GO) test ./... -tags=service_broker
+	$(GO) test $(PKG)/brokerapi/... $(PKG)/cmd/... $(PKG)/db_service/... $(PKG)/internal/... $(PKG)/pkg/... $(PKG)/utils/... -tags=service_broker
+
+.PHONY: test-integration
+test-integration: deps-go-binary ## run integration tests
+	$(GO) run github.com/onsi/ginkgo/ginkgo -p integrationtest/...
 
 ###### Build ##################################################################
 
@@ -69,7 +75,7 @@ generate: ## generate test fakes
 
 .PHONY: download
 download: ## download go module dependencies
-	${GO} mod download -x
+	${GO} mod download
 
 ###### Package ################################################################
 

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,7 @@ github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LB
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=

--- a/integrationtest/brokerpaks_test.go
+++ b/integrationtest/brokerpaks_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Brokerpaks", func() {
 			command := exec.Command(csb, "pak", "build", path.Join(fixturesDir, "brokerpak-with-duplicate-plan-id"))
 			session, err := Start(command, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
-			session.Wait(time.Minute)
+			session.Wait(10 * time.Minute)
 
 			Expect(session.ExitCode()).NotTo(BeZero())
 			Expect(session.Err).To(Say("duplicated value, must be unique: 8b52a460-b246-11eb-a8f5-d349948e2480: services\\[1\\].plans\\[1\\].Id\n"))
@@ -65,7 +65,7 @@ var _ = Describe("Brokerpaks", func() {
 				command := exec.Command(csb, "pak", "build", path.Join(fixturesDir, "brokerpak-file-inclusion"))
 				session, err := Start(command, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
-				session.Wait(time.Minute)
+				session.Wait(10 * time.Minute)
 
 				Expect(session.ExitCode()).To(BeZero())
 

--- a/integrationtest/catalog_test.go
+++ b/integrationtest/catalog_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Catalog", func() {
 		buildBrokerpakCommand := exec.Command(csb, "pak", "build", fixturesDir)
 		session, err := Start(buildBrokerpakCommand, GinkgoWriter, GinkgoWriter)
 		Expect(err).NotTo(HaveOccurred())
-		Eventually(session, time.Minute).Should(Exit(0))
+		Eventually(session, 10*time.Minute).Should(Exit(0))
 
 		brokerUsername = uuid.New()
 		brokerPassword = uuid.New()
@@ -107,7 +107,7 @@ var _ = Describe("Catalog", func() {
 			var err error
 			brokerSession, err = Start(runBrokerCommand, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
-			brokerSession.Wait(time.Minute)
+			brokerSession.Wait(10 * time.Minute)
 
 			Expect(brokerSession.ExitCode()).NotTo(BeZero())
 			Expect(brokerSession.Err).To(Say("duplicated value, must be unique: 8b52a460-b246-11eb-a8f5-d349948e2480: services\\[1\\].Plans\\[1\\].Id\n"))

--- a/integrationtest/database_encryption_test.go
+++ b/integrationtest/database_encryption_test.go
@@ -163,7 +163,7 @@ var _ = Describe("Database Encryption", func() {
 		buildBrokerpakCommand := exec.Command(csb, "pak", "build", fixturesDir)
 		session, err := Start(buildBrokerpakCommand, GinkgoWriter, GinkgoWriter)
 		Expect(err).NotTo(HaveOccurred())
-		Eventually(session, time.Minute).Should(Exit(0))
+		Eventually(session, 10*time.Minute).Should(Exit(0))
 
 		brokerUsername = uuid.New()
 		brokerPassword = uuid.New()

--- a/integrationtest/integrationtest_suite_test.go
+++ b/integrationtest/integrationtest_suite_test.go
@@ -20,15 +20,21 @@ func TestIntegration(t *testing.T) {
 
 var csb string
 
-var _ = BeforeSuite(func() {
-	var err error
-	csb, err = Build("github.com/cloudfoundry-incubator/cloud-service-broker")
-	Expect(err).NotTo(HaveOccurred())
-})
+var _ = SynchronizedBeforeSuite(
+	func() []byte {
+		path, err := Build("github.com/cloudfoundry-incubator/cloud-service-broker")
+		Expect(err).NotTo(HaveOccurred())
+		return []byte(path)
+	},
+	func(data []byte) {
+		csb = string(data)
+	},
+)
 
-var _ = AfterSuite(func() {
-	CleanupBuildArtifacts()
-})
+var _ = SynchronizedAfterSuite(
+	func() {},
+	func() { CleanupBuildArtifacts() },
+)
 
 func freePort() int {
 	listener, err := net.Listen("tcp", "localhost:0")

--- a/integrationtest/subsume_test.go
+++ b/integrationtest/subsume_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Subsume", func() {
 		buildBrokerpakCommand := exec.Command(csb, "pak", "build", fixturesDir)
 		session, err := Start(buildBrokerpakCommand, GinkgoWriter, GinkgoWriter)
 		Expect(err).NotTo(HaveOccurred())
-		Eventually(session, time.Minute).Should(Exit(0))
+		Eventually(session, 10*time.Minute).Should(Exit(0))
 
 		brokerUsername = uuid.New()
 		brokerPassword = uuid.New()

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -4,6 +4,7 @@ package tools
 
 import (
 	_ "github.com/maxbrunsfeld/counterfeiter/v6"
+	_ "github.com/onsi/ginkgo/ginkgo"
 	_ "golang.org/x/tools/cmd/goimports"
 	_ "honnef.co/go/tools/cmd/staticcheck"
 )


### PR DESCRIPTION
Integration tests benefit from being run in parallel, and because they
are Ginkgo style tests, need to be run by the ginkgo command to run in
parallel. For now we can run the other tests with `go test` as this
represents less change. The testing times are quite varaible, but this
appears to speed up the overall time for `make test`.

[#179324852](https://www.pivotaltracker.com/story/show/179324852)