### PR TITLE
Change `blob` to `mediumblob` for terraform.workspace

### DIFF
--- a/db_service/migrations.go
+++ b/db_service/migrations.go
@@ -22,7 +22,7 @@ import (
 	"gorm.io/gorm"
 )
 
-const numMigrations = 14
+const numMigrations = 15
 
 // RunMigrations runs schema migrations on the provided service broker database to get it up to date
 func RunMigrations(db *gorm.DB) error {
@@ -113,6 +113,10 @@ func RunMigrations(db *gorm.DB) error {
 
 	migrations[13] = func() error {
 		return db.Migrator().AlterColumn(&models.TerraformDeploymentV3{}, "workspace")
+	}
+
+	migrations[14] = func() error {
+		return db.Migrator().AlterColumn(&models.TerraformDeploymentV4{}, "workspace")
 	}
 
 	var lastMigrationNumber = -1

--- a/db_service/models/db.go
+++ b/db_service/models/db.go
@@ -145,7 +145,7 @@ type CloudOperation CloudOperationV1
 
 // TerraformDeployment holds Terraform state and plan information for resources
 // that use that execution system.
-type TerraformDeployment TerraformDeploymentV3
+type TerraformDeployment TerraformDeploymentV4
 
 func (t *TerraformDeployment) SetWorkspace(value string) error {
 	encrypted, err := encryptorInstance.Encrypt([]byte(value))

--- a/db_service/models/historical_db.go
+++ b/db_service/models/historical_db.go
@@ -365,6 +365,36 @@ func (TerraformDeploymentV3) TableName() string {
 	return "terraform_deployments"
 }
 
+// TerraformDeploymentV4 expands the size of the Workspace column to handle deployments where the
+// Terraform workspace is greater than 64K. (mediumblob allows for workspaces up
+// to 16384K.)
+type TerraformDeploymentV4 struct {
+	ID        string `gorm:"primary_key;type:varchar(1024)"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt *time.Time
+
+	// Workspace contains a JSON serialized version of the Terraform workspace.
+	Workspace []byte `gorm:"type:mediumblob"`
+
+	// LastOperationType describes the last operation being performed on the resource.
+	LastOperationType string
+
+	// LastOperationState holds one of the following strings "in progress", "succeeded", "failed".
+	// These mirror the OSB API.
+	LastOperationState string
+
+	// LastOperationMessage is a description that can be passed back to the user.
+	LastOperationMessage string `gorm:"type:text"`
+}
+
+// TableName returns a consistent table name for
+// gorm so multiple structs from different versions of the database all operate
+// on the same table.
+func (TerraformDeploymentV4) TableName() string {
+	return "terraform_deployments"
+}
+
 // PasswordMetadataV1 contains information about the passwords, but never the
 // passwords themselves
 type PasswordMetadataV1 struct {


### PR DESCRIPTION
Terraform workspace field used to be a `mediumtext` and then moved to `blob`. The size of the `blob is smaller than `mediumtext` resulting in failures during migration.

[#180161941](https://www.pivotaltracker.com/story/show/180161941)

closes #320 