### PR TITLE
Edit migrations make sure they succeed

### DIFF
--- a/db_service/migrations.go
+++ b/db_service/migrations.go
@@ -112,11 +112,15 @@ func RunMigrations(db *gorm.DB) error {
 	}
 
 	migrations[13] = func() error {
-		return db.Migrator().AlterColumn(&models.TerraformDeploymentV3{}, "workspace")
+		// This used to be a migration step that altered TerraformDeployment workspace field type from mediumtext to blob.
+		// That resulted in decreased field capacity (16384K to 64K).
+		// In order to keep the right number of migrations and fix the issue we should keep this migration id and add
+		// one more to update to larger field size.
+		return nil
 	}
 
 	migrations[14] = func() error {
-		return db.Migrator().AlterColumn(&models.TerraformDeploymentV4{}, "workspace")
+		return db.Migrator().AlterColumn(&models.TerraformDeploymentV3{}, "workspace")
 	}
 
 	var lastMigrationNumber = -1

--- a/db_service/models/db.go
+++ b/db_service/models/db.go
@@ -145,7 +145,7 @@ type CloudOperation CloudOperationV1
 
 // TerraformDeployment holds Terraform state and plan information for resources
 // that use that execution system.
-type TerraformDeployment TerraformDeploymentV4
+type TerraformDeployment TerraformDeploymentV3
 
 func (t *TerraformDeployment) SetWorkspace(value string) error {
 	encrypted, err := encryptorInstance.Encrypt([]byte(value))

--- a/db_service/models/historical_db.go
+++ b/db_service/models/historical_db.go
@@ -335,40 +335,8 @@ func (TerraformDeploymentV2) TableName() string {
 	return "terraform_deployments"
 }
 
-// TerraformDeploymentV3 expands the size of the Workspace column to handle deployments where the
-// Terraform workspace is greater than 64K. (mediumtext allows for workspaces up
-// to 16384K.)
+// TerraformDeploymentV3 converts workspace type from mediumtext to mediumblob
 type TerraformDeploymentV3 struct {
-	ID        string `gorm:"primary_key;type:varchar(1024)"`
-	CreatedAt time.Time
-	UpdatedAt time.Time
-	DeletedAt *time.Time
-
-	// Workspace contains a JSON serialized version of the Terraform workspace.
-	Workspace []byte `gorm:"type:blob"`
-
-	// LastOperationType describes the last operation being performed on the resource.
-	LastOperationType string
-
-	// LastOperationState holds one of the following strings "in progress", "succeeded", "failed".
-	// These mirror the OSB API.
-	LastOperationState string
-
-	// LastOperationMessage is a description that can be passed back to the user.
-	LastOperationMessage string `gorm:"type:text"`
-}
-
-// TableName returns a consistent table name for
-// gorm so multiple structs from different versions of the database all operate
-// on the same table.
-func (TerraformDeploymentV3) TableName() string {
-	return "terraform_deployments"
-}
-
-// TerraformDeploymentV4 expands the size of the Workspace column to handle deployments where the
-// Terraform workspace is greater than 64K. (mediumblob allows for workspaces up
-// to 16384K.)
-type TerraformDeploymentV4 struct {
 	ID        string `gorm:"primary_key;type:varchar(1024)"`
 	CreatedAt time.Time
 	UpdatedAt time.Time
@@ -391,7 +359,7 @@ type TerraformDeploymentV4 struct {
 // TableName returns a consistent table name for
 // gorm so multiple structs from different versions of the database all operate
 // on the same table.
-func (TerraformDeploymentV4) TableName() string {
+func (TerraformDeploymentV3) TableName() string {
 	return "terraform_deployments"
 }
 


### PR DESCRIPTION
Keeping step 13 as it was would have still failed for cases when the DB already had large workspaces stored (bigger than 64K). We still need the migration id, but it should not run any migration, instead step 14 will make sure the blob size is increased.

[#180161941](https://www.pivotaltracker.com/story/show/180161941)

closes #320 