### PR TITLE
chore: update cf manifest to Go 1.17

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -23,5 +23,5 @@ applications:
   - go_buildpack
   env:
     GOPACKAGENAME: github.com/cloudfoundry-incubator/cloud-service-broker
-    GOVERSION: go1.16
+    GOVERSION: go1.17
   random-route: true


### PR DESCRIPTION
Looks like we missed this in 5e194ab