### PR TITLE
fix: persist parameters through multiple updates

### DIFF
--- a/integrationtest/database_encryption_test.go
+++ b/integrationtest/database_encryption_test.go
@@ -26,6 +26,7 @@ var _ = Describe("Database Encryption", func() {
 		provisionParams           = `{"foo":"bar"}`
 		bindParams                = `{"baz":"quz"}`
 		updateParams              = `{"update_input": "update output value"}`
+		mergedParams              = `{"foo":"bar","update_input":"update output value"}`
 		provisionOutput           = `{"provision_output":"provision output value"}`
 		provisionOutputStateValue = `value = \"provision output value\"`
 		updateOutput              = `{"provision_output":"provision output value","update_output":"update output value"}`
@@ -199,6 +200,7 @@ var _ = Describe("Database Encryption", func() {
 	}
 
 	bePlaintextProvisionParams := Equal([]byte(provisionParams))
+	bePlaintextMergedParams := Equal([]byte(mergedParams))
 	bePlaintextProvisionOutput := Equal([]byte(provisionOutput))
 	bePlaintextInstanceTerraformState := SatisfyAll(
 		ContainSubstring(provisionOutputStateValue),
@@ -283,7 +285,7 @@ var _ = Describe("Database Encryption", func() {
 
 			By("checking how update persists service instance fields")
 			updateServiceInstance(serviceInstanceGUID)
-			Expect(persistedRequestDetails(serviceInstanceGUID)).To(bePlaintextProvisionParams)
+			Expect(persistedRequestDetails(serviceInstanceGUID)).To(bePlaintextMergedParams)
 			Expect(persistedServiceInstanceDetails(serviceInstanceGUID)).To(Equal([]byte(updateOutput)))
 			Expect(persistedServiceInstanceTerraformWorkspace(serviceInstanceGUID)).To(SatisfyAll(
 				ContainSubstring(provisionOutputStateValue),
@@ -340,7 +342,7 @@ var _ = Describe("Database Encryption", func() {
 
 			By("checking how update persists service instance fields")
 			updateServiceInstance(serviceInstanceGUID)
-			Expect(persistedRequestDetails(serviceInstanceGUID)).NotTo(Equal(provisionParams))
+			Expect(persistedRequestDetails(serviceInstanceGUID)).NotTo(Equal(mergedParams))
 			Expect(persistedServiceInstanceDetails(serviceInstanceGUID)).NotTo(Equal(updateOutput))
 			Expect(persistedServiceInstanceTerraformWorkspace(serviceInstanceGUID)).NotTo(SatisfyAny(
 				ContainSubstring(provisionOutputStateValue),

--- a/integrationtest/fixtures/brokerpak-for-multiple-updates/fake-bind.tf
+++ b/integrationtest/fixtures/brokerpak-for-multiple-updates/fake-bind.tf
@@ -1,0 +1,3 @@
+variable alpha_output { type = string }
+variable beta_output { type = string }
+output bind_output { value = "${var.alpha_output};${var.beta_output}" }

--- a/integrationtest/fixtures/brokerpak-for-multiple-updates/fake-provision.tf
+++ b/integrationtest/fixtures/brokerpak-for-multiple-updates/fake-provision.tf
@@ -1,0 +1,4 @@
+variable alpha_input { type = string }
+variable beta_input { type = string }
+output alpha_output { value = "${var.alpha_input}" }
+output beta_output { value = "${var.beta_input}" }

--- a/integrationtest/fixtures/brokerpak-for-multiple-updates/fake-service.yml
+++ b/integrationtest/fixtures/brokerpak-for-multiple-updates/fake-service.yml
@@ -1,0 +1,44 @@
+version: 1
+name: fake-service
+id: 76c5725c-b246-11eb-871f-ffc97563fbd0
+description: description
+display_name: Fake
+image_url: https://example.com/icon.jpg
+documentation_url: https://example.com
+support_url: https://example.com/support.html
+plans:
+- name: first
+  id: 8b52a460-b246-11eb-a8f5-d349948e2480
+  description: First plan
+  display_name: First
+provision:
+  template_refs:
+    main: fake-provision.tf
+  user_inputs:
+    - field_name: alpha_input
+      type: string
+      details: alpha input
+    - field_name: beta_input
+      type: string
+      details: beta input
+  outputs:
+    - field_name: alpha_output
+      type: string
+      details: alpha output
+    - field_name: beta_output
+      type: string
+      details: beta output
+bind:
+  template_refs:
+    main: fake-bind.tf
+  computed_inputs:
+    - name: alpha_output
+      type: string
+      default: ${instance.details["alpha_output"]}
+    - name: beta_output
+      type: string
+      default: ${instance.details["beta_output"]}
+  outputs:
+    - field_name: bind_output
+      type: string
+      details: bind output

--- a/integrationtest/fixtures/brokerpak-for-multiple-updates/manifest.yml
+++ b/integrationtest/fixtures/brokerpak-for-multiple-updates/manifest.yml
@@ -1,0 +1,16 @@
+packversion: 1
+name: fake-brokerpak
+version: 0.1.0
+metadata:
+  author: noone@nowhere.com
+platforms:
+- os: linux
+  arch: amd64
+- os: darwin
+  arch: amd64
+terraform_binaries:
+- name: terraform
+  version: 0.12.21
+  source: https://github.com/hashicorp/terraform/archive/v0.12.21.zip
+service_definitions:
+- fake-service.yml

--- a/integrationtest/multiple_update_test.go
+++ b/integrationtest/multiple_update_test.go
@@ -1,0 +1,140 @@
+package integrationtest_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path"
+	"time"
+
+	"github.com/cloudfoundry-incubator/cloud-service-broker/pkg/client"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+	"github.com/pborman/uuid"
+	"github.com/pivotal-cf/brokerapi/v8/domain"
+)
+
+var _ = Describe("Multiple Updates", func() {
+	const (
+		serviceOfferingGUID = "76c5725c-b246-11eb-871f-ffc97563fbd0"
+		servicePlanGUID     = "8b52a460-b246-11eb-a8f5-d349948e2480"
+	)
+
+	var (
+		originalDir         string
+		fixturesDir         string
+		workDir             string
+		brokerPort          int
+		brokerUsername      string
+		brokerPassword      string
+		brokerSession       *Session
+		brokerClient        *client.Client
+		databaseFile        string
+		serviceInstanceGUID string
+	)
+
+	BeforeEach(func() {
+		var err error
+		originalDir, err = os.Getwd()
+		Expect(err).NotTo(HaveOccurred())
+		fixturesDir = path.Join(originalDir, "fixtures")
+
+		workDir, err = os.MkdirTemp("", "*-csb-test")
+		Expect(err).NotTo(HaveOccurred())
+		err = os.Chdir(workDir)
+		Expect(err).NotTo(HaveOccurred())
+
+		command := exec.Command(csb, "pak", "build", path.Join(fixturesDir, "brokerpak-for-multiple-updates"))
+		session, err := Start(command, GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+		session.Wait(10 * time.Minute)
+
+		brokerUsername = uuid.New()
+		brokerPassword = uuid.New()
+		brokerPort = freePort()
+		databaseFile = path.Join(workDir, "databaseFile.dat")
+		runBrokerCommand := exec.Command(csb, "serve")
+		runBrokerCommand.Env = append(
+			os.Environ(),
+			"CSB_LISTENER_HOST=localhost",
+			"DB_TYPE=sqlite3",
+			fmt.Sprintf("DB_PATH=%s", databaseFile),
+			fmt.Sprintf("PORT=%d", brokerPort),
+			fmt.Sprintf("SECURITY_USER_NAME=%s", brokerUsername),
+			fmt.Sprintf("SECURITY_USER_PASSWORD=%s", brokerPassword),
+		)
+		brokerSession, err = Start(runBrokerCommand, GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+		waitForBrokerToStart(brokerPort)
+
+		brokerClient, err = client.New(brokerUsername, brokerPassword, "localhost", brokerPort)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		brokerSession.Terminate()
+
+		err := os.Chdir(originalDir)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = os.RemoveAll(workDir)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	checkBindingOutput := func(expected string) {
+		bindResponse := brokerClient.Bind(serviceInstanceGUID, uuid.New(), serviceOfferingGUID, servicePlanGUID, requestID(), nil)
+		ExpectWithOffset(1, bindResponse.Error).NotTo(HaveOccurred())
+		ExpectWithOffset(1, string(bindResponse.ResponseBody)).To(ContainSubstring(expected))
+	}
+
+	waitForCompletion := func() {
+		Eventually(func() bool {
+			lastOperationResponse := brokerClient.LastOperation(serviceInstanceGUID, requestID())
+			Expect(lastOperationResponse.Error).NotTo(HaveOccurred())
+			Expect(lastOperationResponse.StatusCode).To(Equal(http.StatusOK))
+			var receiver domain.LastOperation
+			err := json.Unmarshal(lastOperationResponse.ResponseBody, &receiver)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(receiver.State).NotTo(Equal("failed"))
+			return receiver.State == "succeeded"
+		}, time.Minute*2, time.Second*10).Should(BeTrue())
+	}
+
+	// This test was added for issue https://www.pivotaltracker.com/story/show/178213626 where a parameter that was
+	// updated would be reverted to the default value in subsequent updates
+	It("persists updated parameters in subsequent updates", func() {
+		By("provisioning with parameters")
+		const provisionParams = `{"alpha_input":"foo","beta_input":"bar"}`
+		serviceInstanceGUID = uuid.New()
+		provisionResponse := brokerClient.Provision(serviceInstanceGUID, serviceOfferingGUID, servicePlanGUID, requestID(), []byte(provisionParams))
+		Expect(provisionResponse.Error).NotTo(HaveOccurred())
+		Expect(provisionResponse.StatusCode).To(Equal(http.StatusAccepted))
+		waitForCompletion()
+
+		By("checking that the parameter values are in a binding")
+		checkBindingOutput(`"bind_output":"foo;bar"`)
+
+		By("updating a parameter")
+		const updateOneParams = `{"beta_input":"baz"}`
+		updateOneResponse := brokerClient.Update(serviceInstanceGUID, serviceOfferingGUID, servicePlanGUID, requestID(), []byte(updateOneParams))
+		Expect(updateOneResponse.Error).NotTo(HaveOccurred())
+		Expect(updateOneResponse.StatusCode).To(Equal(http.StatusAccepted))
+		waitForCompletion()
+
+		By("checking the value is updated in a binding")
+		checkBindingOutput(`"bind_output":"foo;baz"`)
+
+		By("updating another parameter")
+		const updateTwoParams = `{"alpha_input":"quz"}`
+		updateTwoResponse := brokerClient.Update(serviceInstanceGUID, serviceOfferingGUID, servicePlanGUID, requestID(), []byte(updateTwoParams))
+		Expect(updateTwoResponse.Error).NotTo(HaveOccurred())
+		Expect(updateTwoResponse.StatusCode).To(Equal(http.StatusAccepted))
+		waitForCompletion()
+
+		By("checking that both parameters remain updated in a binding")
+		checkBindingOutput(`"bind_output":"quz;baz"`)
+	})
+})

--- a/pkg/varcontext/builder_test.go
+++ b/pkg/varcontext/builder_test.go
@@ -134,6 +134,30 @@ func TestContextBuilder(t *testing.T) {
 			Builder:     Builder().MergeJsonObject(json.RawMessage(`{{{}}}`)),
 			ErrContains: "invalid character '{'",
 		},
+		"MergeJsonObject merge multiple": {
+			Builder:  Builder().MergeJsonObject(json.RawMessage(`{"foo":"bar"}`)).MergeJsonObject(json.RawMessage(`{"baz":"quz"}`)),
+			Expected: map[string]interface{}{"foo": "bar", "baz": "quz"},
+		},
+		"MergeJsonObject duplicate keys at top level": {
+			Builder:  Builder().MergeJsonObject(json.RawMessage(`{"foo":"bar","baz":"bar"}`)).MergeJsonObject(json.RawMessage(`{"baz":"quz"}`)),
+			Expected: map[string]interface{}{"foo": "bar", "baz": "quz"},
+		},
+		"MergeJsonObject only merges top level key/values": {
+			Builder:  Builder().MergeJsonObject(json.RawMessage(`{"foo":{"bar":"baz","quz":"buz"}}`)).MergeJsonObject(json.RawMessage(`{"foo":{"bar":"quz"}}`)),
+			Expected: map[string]interface{}{"foo": map[string]interface{}{"bar": "quz"}},
+		},
+		"MergeJsonObject merge first empty object": {
+			Builder:  Builder().MergeJsonObject(json.RawMessage(`{}`)).MergeJsonObject(json.RawMessage(`{"baz":"quz"}`)),
+			Expected: map[string]interface{}{"baz": "quz"},
+		},
+		"MergeJsonObject merge second empty object": {
+			Builder:  Builder().MergeJsonObject(json.RawMessage(`{"baz":"quz"}`)).MergeJsonObject(json.RawMessage(`{}`)),
+			Expected: map[string]interface{}{"baz": "quz"},
+		},
+		"MergeJsonObject merge JSON non-object": {
+			Builder:     Builder().MergeJsonObject(json.RawMessage(`{"baz":"quz"}`)).MergeJsonObject(json.RawMessage(`true`)),
+			ErrContains: "json: cannot unmarshal bool into Go value of type map[string]interface {}",
+		},
 
 		// MergeStruct
 		"MergeStruct without JSON Tags": {


### PR DESCRIPTION
Stores the merged previous and provided user parameters so that on
subsequent updates, they do not need to be provided again.

For example:
  provision: {"foo":"bar","baz":"quz"}
  update 1: {"foo":"dax"} -> {"foo":"dax","baz":"quz"}
  update 2 before fix: {"baz":"box"} -> {"foo":"bar","bax":"box"}
  update 2 after fix:  {"baz":"box"} -> {"foo":"dax","bax":"box"}

[#178213626](https://www.pivotaltracker.com/story/show/178213626)