### PR TITLE
fix: reject undefined provision parameters

### DIFF
--- a/integrationtest/brokerpak_update_test.go
+++ b/integrationtest/brokerpak_update_test.go
@@ -24,7 +24,7 @@ import (
 
 var _ = Describe("Brokerpak Update", func() {
 	const (
-		provisionParams             = `{"foo":"bar"}`
+		provisionParams             = `{"provision_input":"bar"}`
 		bindParams                  = `{"baz":"quz"}`
 		updateParams                = `{"update_input": "update output value"}`
 		updateOutputStateKey        = `"update_output"`
@@ -67,7 +67,6 @@ var _ = Describe("Brokerpak Update", func() {
 		findRecord(&record, tfWorkspaceIdQuery, fmt.Sprintf("tf:%s:%s", serviceInstanceGUID, serviceBindingGUID))
 		ws, _ := wrapper.DeserializeWorkspace(string(record.Workspace))
 		return ws
-
 	}
 
 	createBinding := func(serviceInstanceGUID, serviceBindingGUID string) {
@@ -102,8 +101,8 @@ var _ = Describe("Brokerpak Update", func() {
 
 	provisionServiceInstance := func(serviceInstanceGUID string) {
 		provisionResponse := brokerClient.Provision(serviceInstanceGUID, serviceOfferingGUID, servicePlanGUID, uuid.New(), []byte(provisionParams))
-		Expect(provisionResponse.Error).NotTo(HaveOccurred())
-		Expect(provisionResponse.StatusCode).To(Equal(http.StatusAccepted))
+		ExpectWithOffset(1, provisionResponse.Error).NotTo(HaveOccurred())
+		ExpectWithOffset(1, provisionResponse.StatusCode).To(Equal(http.StatusAccepted), string(provisionResponse.ResponseBody))
 
 		waitForAsyncRequest(serviceInstanceGUID)
 	}
@@ -263,7 +262,6 @@ var _ = Describe("Brokerpak Update", func() {
 			deprovisionServiceInstance(serviceInstanceGUID)
 			Expect(persistedTerraformModuleDefinition(serviceInstanceGUID, "")).To(beInitialTerraformHCL)
 			Expect(persistedTerraformState(serviceInstanceGUID, "")).To(haveEmtpyState)
-
 		})
 
 		It("uses the initial HCL for binding operations", func() {
@@ -277,9 +275,7 @@ var _ = Describe("Brokerpak Update", func() {
 
 			Expect(persistedTerraformModuleDefinition(serviceInstanceGUID, serviceBindingGUID)).To(beInitialBindingTerraformHCL)
 			Expect(persistedTerraformState(serviceInstanceGUID, serviceBindingGUID)).To(haveEmtpyState)
-
 		})
-
 	})
 
 	When("brokerpak updates are enabled", func() {
@@ -333,8 +329,6 @@ var _ = Describe("Brokerpak Update", func() {
 
 			Expect(persistedTerraformModuleDefinition(serviceInstanceGUID, serviceBindingGUID)).To(beUpdatedBindingTerraformHCL)
 			Expect(persistedTerraformState(serviceInstanceGUID, serviceBindingGUID)).To(haveEmtpyState)
-
 		})
-
 	})
 })

--- a/integrationtest/fixtures/brokerpak-for-subsume-cancel/fake-string-service.yml
+++ b/integrationtest/fixtures/brokerpak-for-subsume-cancel/fake-string-service.yml
@@ -32,3 +32,7 @@ provision:
     - field_name: subsume
       type: boolean
       details: Subsume existing
+  user_inputs:
+    - field_name: value
+      type: string
+      details: Subsume input

--- a/integrationtest/fixtures/brokerpak-for-subsume-cancel/fake-uuid-service.yml
+++ b/integrationtest/fixtures/brokerpak-for-subsume-cancel/fake-uuid-service.yml
@@ -29,3 +29,7 @@ provision:
     - field_name: subsume
       type: boolean
       details: Subsume existing
+  user_inputs:
+    - field_name: value
+      type: string
+      details: Subsume input

--- a/integrationtest/fixtures/brokerpak-with-fake-provider-updated/fake-service.yml
+++ b/integrationtest/fixtures/brokerpak-with-fake-provider-updated/fake-service.yml
@@ -15,6 +15,9 @@ provision:
   template_refs:
     main: fake-provision.tf
   user_inputs:
+    - field_name: provision_input
+      type: string
+      details: allowed param during provision
     - field_name: update_input
       type: string
       details: input to be returned during update

--- a/integrationtest/fixtures/brokerpak-with-fake-provider/fake-service.yml
+++ b/integrationtest/fixtures/brokerpak-with-fake-provider/fake-service.yml
@@ -15,6 +15,9 @@ provision:
   template_refs:
     main: fake-provision.tf
   user_inputs:
+    - field_name: provision_input
+      type: string
+      details: allowed param during provision
     - field_name: update_input
       type: string
       details: to modify during update

--- a/integrationtest/subsume_test.go
+++ b/integrationtest/subsume_test.go
@@ -70,7 +70,6 @@ var _ = Describe("Subsume", func() {
 
 		brokerClient, err = client.New(brokerUsername, brokerPassword, "localhost", brokerPort)
 		Expect(err).NotTo(HaveOccurred())
-
 	})
 
 	AfterEach(func() {
@@ -89,7 +88,7 @@ var _ = Describe("Subsume", func() {
 		serviceInstanceGUID = uuid.New()
 		provisionResponse := brokerClient.Provision(serviceInstanceGUID, serviceOfferingGUID, servicePlanGUID, uuid.New(), []byte(`{"value":"a97fd57a-fa94-11eb-8256-930255607a99"}`))
 		Expect(provisionResponse.Error).NotTo(HaveOccurred())
-		Expect(provisionResponse.StatusCode).To(Equal(http.StatusAccepted))
+		Expect(provisionResponse.StatusCode).To(Equal(http.StatusAccepted), string(provisionResponse.ResponseBody))
 
 		Eventually(func() bool {
 			lastOperationResponse := brokerClient.LastOperation(serviceInstanceGUID, requestID())
@@ -110,7 +109,7 @@ var _ = Describe("Subsume", func() {
 		serviceInstanceGUID = uuid.New()
 		provisionResponse := brokerClient.Provision(serviceInstanceGUID, serviceOfferingGUID, servicePlanGUID, uuid.New(), []byte(`{"value":"thisisnotrandomatall"}`))
 		Expect(provisionResponse.Error).NotTo(HaveOccurred())
-		Expect(provisionResponse.StatusCode).To(Equal(http.StatusAccepted))
+		Expect(provisionResponse.StatusCode).To(Equal(http.StatusAccepted), string(provisionResponse.ResponseBody))
 
 		var receiver domain.LastOperation
 		Eventually(func() bool {


### PR DESCRIPTION
We have had some experiences where users accidentally mistype provision
parameters, for example speciflying '{"location":"eu-west-1"}' instead
of '{"region":"eu-west-1"}'. Previously this resulted in success because
the undefined field was ignored. But it's a much better experience for
the user if there is a failure that they can act on.

Additionally, it was noted that in some integration tests, the broker
would not be terminated if the test failed. This has been updated to
move the termination to an `AfterEach()` block.

[#178067889](https://www.pivotaltracker.com/story/show/178067889)

Co-authored-by: James Norman <normanja@vmware.com>