### PR TITLE
test: use Ginkgo TempDir() rather than os.MkdirTemp()

### DIFF
--- a/integrationtest/brokerpak_update_test.go
+++ b/integrationtest/brokerpak_update_test.go
@@ -188,15 +188,6 @@ var _ = Describe("Brokerpak Update", func() {
 	buildBrokerpakFor := func(fixtureName string) {
 		var err error
 
-		if workDir == "" {
-			originalDir, err = os.Getwd()
-			Expect(err).NotTo(HaveOccurred())
-			workDir, err = os.MkdirTemp("", "*-csb-test")
-			Expect(err).NotTo(HaveOccurred())
-		}
-		err = os.Chdir(workDir)
-		Expect(err).NotTo(HaveOccurred())
-
 		fixturesDir = path.Join(originalDir, "fixtures", fixtureName)
 		buildBrokerpakCommand := exec.Command(csb, "pak", "build", fixturesDir)
 		session, err := Start(buildBrokerpakCommand, GinkgoWriter, GinkgoWriter)
@@ -213,6 +204,13 @@ var _ = Describe("Brokerpak Update", func() {
 	BeforeEach(func() {
 		var err error
 
+		originalDir, err = os.Getwd()
+		Expect(err).NotTo(HaveOccurred())
+
+		workDir = GinkgoT().TempDir()
+		err = os.Chdir(workDir)
+		Expect(err).NotTo(HaveOccurred())
+
 		buildBrokerpakFor(initialBrokerpak)
 
 		brokerUsername = uuid.New()
@@ -227,10 +225,6 @@ var _ = Describe("Brokerpak Update", func() {
 	AfterEach(func() {
 		err := os.Chdir(originalDir)
 		Expect(err).NotTo(HaveOccurred())
-
-		err = os.RemoveAll(workDir)
-		Expect(err).NotTo(HaveOccurred())
-		workDir = ""
 	})
 
 	When("brokerpak updates are disabled", func() {

--- a/integrationtest/brokerpaks_test.go
+++ b/integrationtest/brokerpaks_test.go
@@ -27,17 +27,13 @@ var _ = Describe("Brokerpaks", func() {
 		Expect(err).NotTo(HaveOccurred())
 		fixturesDir = path.Join(originalDir, "fixtures")
 
-		workDir, err = os.MkdirTemp("", "*-csb-test")
-		Expect(err).NotTo(HaveOccurred())
+		workDir = GinkgoT().TempDir()
 		err = os.Chdir(workDir)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		err := os.Chdir(originalDir)
-		Expect(err).NotTo(HaveOccurred())
-
-		err = os.RemoveAll(workDir)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/integrationtest/catalog_test.go
+++ b/integrationtest/catalog_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 var _ = Describe("Catalog", func() {
-
 	var (
 		originalDir      string
 		fixturesDir      string
@@ -35,9 +34,8 @@ var _ = Describe("Catalog", func() {
 		Expect(err).NotTo(HaveOccurred())
 		fixturesDir = path.Join(originalDir, "fixtures", "brokerpak-for-catalog-test")
 
-		workDir, err = os.MkdirTemp("", "*-csb-test")
-		Expect(err).NotTo(HaveOccurred())
-		err = os.Chdir(workDir)
+		workDir = GinkgoT().TempDir()
+		os.Chdir(workDir)
 		Expect(err).NotTo(HaveOccurred())
 
 		buildBrokerpakCommand := exec.Command(csb, "pak", "build", fixturesDir)
@@ -56,9 +54,6 @@ var _ = Describe("Catalog", func() {
 		brokerSession.Terminate()
 
 		err := os.Chdir(originalDir)
-		Expect(err).NotTo(HaveOccurred())
-
-		err = os.RemoveAll(workDir)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/integrationtest/catalog_test.go
+++ b/integrationtest/catalog_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Catalog", func() {
 		fixturesDir = path.Join(originalDir, "fixtures", "brokerpak-for-catalog-test")
 
 		workDir = GinkgoT().TempDir()
-		os.Chdir(workDir)
+		err = os.Chdir(workDir)
 		Expect(err).NotTo(HaveOccurred())
 
 		buildBrokerpakCommand := exec.Command(csb, "pak", "build", fixturesDir)

--- a/integrationtest/database_encryption_test.go
+++ b/integrationtest/database_encryption_test.go
@@ -245,8 +245,7 @@ var _ = Describe("Database Encryption", func() {
 		Expect(err).NotTo(HaveOccurred())
 		fixturesDir = path.Join(originalDir, "fixtures", "brokerpak-with-fake-provider")
 
-		workDir, err = os.MkdirTemp("", "*-csb-test")
-		Expect(err).NotTo(HaveOccurred())
+		workDir = GinkgoT().TempDir()
 		err = os.Chdir(workDir)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -268,9 +267,6 @@ var _ = Describe("Database Encryption", func() {
 		brokerSession.Terminate()
 
 		err := os.Chdir(originalDir)
-		Expect(err).NotTo(HaveOccurred())
-
-		err = os.RemoveAll(workDir)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/integrationtest/multiple_update_test.go
+++ b/integrationtest/multiple_update_test.go
@@ -42,8 +42,7 @@ var _ = Describe("Multiple Updates", func() {
 		Expect(err).NotTo(HaveOccurred())
 		fixturesDir = path.Join(originalDir, "fixtures")
 
-		workDir, err = os.MkdirTemp("", "*-csb-test")
-		Expect(err).NotTo(HaveOccurred())
+		workDir = GinkgoT().TempDir()
 		err = os.Chdir(workDir)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -78,9 +77,6 @@ var _ = Describe("Multiple Updates", func() {
 		brokerSession.Terminate()
 
 		err := os.Chdir(originalDir)
-		Expect(err).NotTo(HaveOccurred())
-
-		err = os.RemoveAll(workDir)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/integrationtest/subsume_test.go
+++ b/integrationtest/subsume_test.go
@@ -40,8 +40,7 @@ var _ = Describe("Subsume", func() {
 		Expect(err).NotTo(HaveOccurred())
 		fixturesDir = path.Join(originalDir, "fixtures", "brokerpak-for-subsume-cancel")
 
-		workDir, err = os.MkdirTemp("", "*-csb-test")
-		Expect(err).NotTo(HaveOccurred())
+		workDir = GinkgoT().TempDir()
 		err = os.Chdir(workDir)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -76,9 +75,6 @@ var _ = Describe("Subsume", func() {
 		brokerSession.Terminate()
 
 		err := os.Chdir(originalDir)
-		Expect(err).NotTo(HaveOccurred())
-
-		err = os.RemoveAll(workDir)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/integrationtest/terraform_0.12_test.go
+++ b/integrationtest/terraform_0.12_test.go
@@ -39,8 +39,7 @@ var _ = Describe("Terraform 0.12", func() {
 		Expect(err).NotTo(HaveOccurred())
 		fixturesDir = path.Join(originalDir, "fixtures", "brokerpak-terraform-0.12")
 
-		workDir, err = os.MkdirTemp("", "*-csb-test")
-		Expect(err).NotTo(HaveOccurred())
+		workDir = GinkgoT().TempDir()
 		err = os.Chdir(workDir)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -75,9 +74,6 @@ var _ = Describe("Terraform 0.12", func() {
 		brokerSession.Terminate()
 
 		err := os.Chdir(originalDir)
-		Expect(err).NotTo(HaveOccurred())
-
-		err = os.RemoveAll(workDir)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/integrationtest/terraform_0.13_test.go
+++ b/integrationtest/terraform_0.13_test.go
@@ -39,8 +39,7 @@ var _ = Describe("Terraform 0.13", func() {
 		Expect(err).NotTo(HaveOccurred())
 		fixturesDir = path.Join(originalDir, "fixtures", "brokerpak-terraform-0.13")
 
-		workDir, err = os.MkdirTemp("", "*-csb-test")
-		Expect(err).NotTo(HaveOccurred())
+		workDir = GinkgoT().TempDir()
 		err = os.Chdir(workDir)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -75,9 +74,6 @@ var _ = Describe("Terraform 0.13", func() {
 		brokerSession.Terminate()
 
 		err := os.Chdir(originalDir)
-		Expect(err).NotTo(HaveOccurred())
-
-		err = os.RemoveAll(workDir)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/internal/zippy/archive_test.go
+++ b/internal/zippy/archive_test.go
@@ -1,7 +1,6 @@
 package zippy_test
 
 import (
-	"os"
 	"path"
 
 	. "github.com/cloudfoundry-incubator/cloud-service-broker/internal/testmatchers"
@@ -14,14 +13,7 @@ var _ = Describe("Archive", func() {
 	var tmpdir string
 
 	BeforeEach(func() {
-		var err error
-		tmpdir, err = os.MkdirTemp("", "test")
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	AfterEach(func() {
-		err := os.RemoveAll(tmpdir)
-		Expect(err).NotTo(HaveOccurred())
+		tmpdir = GinkgoT().TempDir()
 	})
 
 	It("creates a zip", func() {

--- a/internal/zippy/extract_test.go
+++ b/internal/zippy/extract_test.go
@@ -17,14 +17,7 @@ var _ = Describe("extraction", func() {
 		var tmpdir string
 
 		BeforeEach(func() {
-			var err error
-			tmpdir, err = os.MkdirTemp("", "test")
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		AfterEach(func() {
-			err := os.RemoveAll(tmpdir)
-			Expect(err).NotTo(HaveOccurred())
+			tmpdir = GinkgoT().TempDir()
 		})
 
 		It("can extract the whole zip", func() {
@@ -89,14 +82,7 @@ var _ = Describe("extraction", func() {
 		var tmpdir string
 
 		BeforeEach(func() {
-			var err error
-			tmpdir, err = os.MkdirTemp("", "test")
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		AfterEach(func() {
-			err := os.RemoveAll(tmpdir)
-			Expect(err).NotTo(HaveOccurred())
+			tmpdir = GinkgoT().TempDir()
 		})
 
 		It("can extract a file from the zip", func() {


### PR DESCRIPTION
The advantage of the Ginkgo helper is that errors are automatically
checked and the directory is automatically cleaned up.