### PR TITLE
chore: expose broker and brokerpak versions in logs

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -79,6 +79,7 @@ func init() {
 
 func serve() {
 	logger := utils.NewLogger("cloud-service-broker")
+	logger.Info("starting", lager.Data{"version": utils.Version})
 	db := db_service.New(logger)
 	encryptor := setupDBEncryption(db, logger)
 

--- a/internal/brokerpak/packer/pack.go
+++ b/internal/brokerpak/packer/pack.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cloudfoundry-incubator/cloud-service-broker/internal/brokerpak/manifest"
 	"github.com/cloudfoundry-incubator/cloud-service-broker/internal/zippy"
 	"github.com/cloudfoundry-incubator/cloud-service-broker/pkg/providers/tf"
+	"github.com/cloudfoundry-incubator/cloud-service-broker/utils"
 	"github.com/cloudfoundry-incubator/cloud-service-broker/utils/stream"
 	"github.com/hashicorp/go-getter"
 )
@@ -22,7 +23,7 @@ const manifestName = "manifest.yml"
 func Pack(m *manifest.Manifest, base, dest string) error {
 	// NOTE: we use "log" rather than Lager because this is used by the CLI and
 	// needs to be human readable rather than JSON.
-	log.Println("Packing...")
+	log.Printf("Packing %q version %q with CSB version %q...\n", base, m.Version, utils.Version)
 
 	dir, err := os.MkdirTemp("", "brokerpak")
 	if err != nil {

--- a/pkg/brokerpak/registrar.go
+++ b/pkg/brokerpak/registrar.go
@@ -88,12 +88,16 @@ func (r *Registrar) Register(registry broker.BrokerRegistry) error {
 			return errs
 		}
 
-		if manifest, err := brokerPak.Manifest(); err == nil {
-			for env, config := range manifest.EnvConfigMapping {
-				viper.BindEnv(config, env)
-			}
+		mf, err := brokerPak.Manifest()
+		if err != nil {
+			return fmt.Errorf("error reading brokerpak manifest: %w", err)
 		}
 
+		for env, config := range mf.EnvConfigMapping {
+			viper.BindEnv(config, env)
+		}
+
+		registerLogger.Info("registration-successful", lager.Data{"version": mf.Version})
 		return nil
 	})
 }

--- a/utils/version.go
+++ b/utils/version.go
@@ -15,9 +15,4 @@
 package utils
 
 // Version sets the version for the whole cloud service broker software.
-var Version = "5.0.0"
-
-// CustomUserAgent is added to provision calls so that Google can track the aggregated use of this tool
-// We can better advocate for devoting resources to supporting cloud foundry and this service broker if we can show
-// good usage statistics for it, so if you feel the need to fork this repo, please leave this string in place!
-var CustomUserAgent = "cf-gcp-service-broker " + Version
+var Version = "0.0.0" // set at build time via "-ldflags"


### PR DESCRIPTION
This allows someone to:
- make sure they are running with the version they think they are
running with
- help debug any issues by being able to identify the version in use

[#177837115](https://www.pivotaltracker.com/story/show/177837115)